### PR TITLE
Breaking tag descriptions out into markdown files

### DIFF
--- a/markdown/en/tags/account-tag-description.md
+++ b/markdown/en/tags/account-tag-description.md
@@ -1,0 +1,1 @@
+Contains information about an account and its settings

--- a/markdown/en/tags/api-app-tag-description.md
+++ b/markdown/en/tags/api-app-tag-description.md
@@ -1,0 +1,1 @@
+Contains information about an API App

--- a/markdown/en/tags/bulk-send-job-tag-description.md
+++ b/markdown/en/tags/bulk-send-job-tag-description.md
@@ -1,0 +1,1 @@
+Contains information about bulk sent signature requests

--- a/markdown/en/tags/embedded-tag-description.md
+++ b/markdown/en/tags/embedded-tag-description.md
@@ -1,0 +1,1 @@
+An object that contains necessary information to set up embedded signing

--- a/markdown/en/tags/report-tag-description.md
+++ b/markdown/en/tags/report-tag-description.md
@@ -1,0 +1,1 @@
+Provides insights into your team's user activity and document status

--- a/markdown/en/tags/signature-request-tag-description.md
+++ b/markdown/en/tags/signature-request-tag-description.md
@@ -1,0 +1,1 @@
+Contains information regarding documents that need to be signed

--- a/markdown/en/tags/team-tag-description.md
+++ b/markdown/en/tags/team-tag-description.md
@@ -1,0 +1,1 @@
+Contains information about your team and its members

--- a/markdown/en/tags/template-tag-description.md
+++ b/markdown/en/tags/template-tag-description.md
@@ -1,0 +1,1 @@
+Contains information about the templates you and your team have created

--- a/markdown/en/tags/unclaimed-draft-tag-description.md
+++ b/markdown/en/tags/unclaimed-draft-tag-description.md
@@ -1,0 +1,1 @@
+A group of documents that a user can take ownership of via the claim URL

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -6924,31 +6924,31 @@ security:
 tags:
   -
     name: Account
-    description: '_t__OpenApi::TAG::ACCOUNT::DESCRIPTION'
+    description: '_md__OpenApi::TAG::ACCOUNT::DESCRIPTION'
   -
     name: 'Signature Request'
-    description: '_t__OpenApi::TAG::SIGNATURE_REQUEST::DESCRIPTION'
+    description: '_md__OpenApi::TAG::SIGNATURE_REQUEST::DESCRIPTION'
   -
     name: Template
-    description: '_t__OpenApi::TAG::TEMPLATE::DESCRIPTION'
+    description: '_md__OpenApi::TAG::TEMPLATE::DESCRIPTION'
   -
     name: 'Bulk Send Job'
-    description: '_t__OpenApi::TAG::BULK_SEND_JOB::DESCRIPTION'
+    description: '_md__OpenApi::TAG::BULK_SEND_JOB::DESCRIPTION'
   -
     name: Report
-    description: '_t__OpenApi::TAG::REPORT::DESCRIPTION'
+    description: '_md__OpenApi::TAG::REPORT::DESCRIPTION'
   -
     name: Team
-    description: '_t__OpenApi::TAG::TEAM::DESCRIPTION'
+    description: '_md__OpenApi::TAG::TEAM::DESCRIPTION'
   -
     name: 'Unclaimed Draft'
-    description: '_t__OpenApi::TAG::UNCLAIMED_DRAFT::DESCRIPTION'
+    description: '_md__OpenApi::TAG::UNCLAIMED_DRAFT::DESCRIPTION'
   -
     name: Embedded
-    description: '_t__OpenApi::TAG::EMBEDDED::DESCRIPTION'
+    description: '_md__OpenApi::TAG::EMBEDDED::DESCRIPTION'
   -
     name: 'Api App'
-    description: '_t__OpenApi::TAG::API_APP::DESCRIPTION'
+    description: '_md__OpenApi::TAG::API_APP::DESCRIPTION'
   -
     name: OAuth
     description: '_md__OpenApi::TAG::OAUTH::DESCRIPTION'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7430,31 +7430,40 @@ security:
 tags:
   -
     name: Account
-    description: 'Contains information about an account and its settings'
+    description:
+      $ref: ./markdown/en/tags/account-tag-description.md
   -
     name: 'Signature Request'
-    description: 'Contains information regarding documents that need to be signed'
+    description:
+      $ref: ./markdown/en/tags/signature-request-tag-description.md
   -
     name: Template
-    description: 'Contains information about the templates you and your team have created'
+    description:
+      $ref: ./markdown/en/tags/template-tag-description.md
   -
     name: 'Bulk Send Job'
-    description: 'Contains information about bulk sent signature requests'
+    description:
+      $ref: ./markdown/en/tags/bulk-send-job-tag-description.md
   -
     name: Report
-    description: 'Provides insights into your team''s user activity and document status'
+    description:
+      $ref: ./markdown/en/tags/report-tag-description.md
   -
     name: Team
-    description: 'Contains information about your team and its members'
+    description:
+      $ref: ./markdown/en/tags/team-tag-description.md
   -
     name: 'Unclaimed Draft'
-    description: 'A group of documents that a user can take ownership of via the claim URL'
+    description:
+      $ref: ./markdown/en/tags/unclaimed-draft-tag-description.md
   -
     name: Embedded
-    description: 'An object that contains necessary information to set up embedded signing'
+    description:
+      $ref: ./markdown/en/tags/embedded-tag-description.md
   -
     name: 'Api App'
-    description: 'Contains information about an API App'
+    description:
+      $ref: ./markdown/en/tags/api-app-tag-description.md
   -
     name: OAuth
     description:

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -38,15 +38,15 @@
   curl 'https://api.hellosign.com/v3/signature_request/list' \
       -H "Authorization: Bearer ${OAUTHTOKEN}"
   ```
-"OpenApi::TAG::ACCOUNT::DESCRIPTION": Contains information about an account and its settings
-"OpenApi::TAG::API_APP::DESCRIPTION": Contains information about an API App
-"OpenApi::TAG::BULK_SEND_JOB::DESCRIPTION": Contains information about bulk sent signature requests
-"OpenApi::TAG::EMBEDDED::DESCRIPTION": An object that contains necessary information to set up embedded signing
-"OpenApi::TAG::REPORT::DESCRIPTION": Provides insights into your team's user activity and document status
-"OpenApi::TAG::SIGNATURE_REQUEST::DESCRIPTION": Contains information regarding documents that need to be signed
-"OpenApi::TAG::TEAM::DESCRIPTION": Contains information about your team and its members
-"OpenApi::TAG::TEMPLATE::DESCRIPTION": Contains information about the templates you and your team have created
-"OpenApi::TAG::UNCLAIMED_DRAFT::DESCRIPTION": A group of documents that a user can take ownership of via the claim URL
+"OpenApi::TAG::ACCOUNT::DESCRIPTION": ./markdown/en/tags/account-tag-description.md
+"OpenApi::TAG::API_APP::DESCRIPTION": ./markdown/en/tags/api-app-tag-description.md
+"OpenApi::TAG::BULK_SEND_JOB::DESCRIPTION": ./markdown/en/tags/bulk-send-job-tag-description.md
+"OpenApi::TAG::EMBEDDED::DESCRIPTION": ./markdown/en/tags/embedded-tag-description.md
+"OpenApi::TAG::REPORT::DESCRIPTION": ./markdown/en/tags/report-tag-description.md
+"OpenApi::TAG::SIGNATURE_REQUEST::DESCRIPTION": ./markdown/en/tags/signature-request-tag-description.md
+"OpenApi::TAG::TEAM::DESCRIPTION": ./markdown/en/tags/team-tag-description.md
+"OpenApi::TAG::TEMPLATE::DESCRIPTION": ./markdown/en/tags/template-tag-description.md
+"OpenApi::TAG::UNCLAIMED_DRAFT::DESCRIPTION": ./markdown/en/tags/unclaimed-draft-tag-description.md
 "OpenApi::TAG::OAUTH::DESCRIPTION": ./markdown/en/tags/oauth-tag-description.md
 "OpenApi::TAG::CALLBACKS_AND_EVENTS::DESCRIPTION": ./markdown/en/tags/callbacks-tag-description.md
 


### PR DESCRIPTION
Pulling tag descriptions into markdown files to make authoring easier.