### PR TITLE
Revert "Add locale parameter in AccountUpdate and AccountCreate to openapi.yaml"

### DIFF
--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -4187,17 +4187,11 @@ components:
           description: '_t__AccountCreate::EMAIL_ADDRESS'
           type: string
           format: email
-        locale:
-          description: '_t__AccountCreate::LOCALE'
-          type: string
       type: object
     AccountUpdateRequest:
       properties:
         callback_url:
           description: '_t__AccountUpdate::CALLBACK_URL'
-          type: string
-        locale:
-          description: '_t__AccountUpdate::LOCALE'
           type: string
       type: object
     AccountVerifyRequest:

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -4262,17 +4262,11 @@ components:
           description: 'The email address to create a new Account for.'
           type: string
           format: email
-        locale:
-          description: 'The locale used in this Account.'
-          type: string
       type: object
     AccountUpdateRequest:
       properties:
         callback_url:
           description: 'The URL that HelloSign should POST events to.'
-          type: string
-        locale:
-          description: 'The locale used in this Account.'
           type: string
       type: object
     AccountVerifyRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4262,17 +4262,11 @@ components:
           description: 'The email address to create a new Account for.'
           type: string
           format: email
-        locale:
-          description: 'The locale used in this Account.'
-          type: string
       type: object
     AccountUpdateRequest:
       properties:
         callback_url:
           description: 'The URL that HelloSign should POST events to.'
-          type: string
-        locale:
-          description: 'The locale used in this Account.'
           type: string
       type: object
     AccountVerifyRequest:

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -71,7 +71,6 @@
 
   See [OAuth 2.0 Authorization](https://app.hellosign.com/api/oauthWalkthrough#OAuthAuthorization)
 "AccountCreate::EMAIL_ADDRESS": The email address to create a new Account for.
-"AccountCreate::LOCALE": The locale used in this Account.
 
 "AccountGet::DESCRIPTION": Returns the properties and settings of your Account.
 "AccountGet::SUMMARY": Get Account
@@ -79,7 +78,6 @@
 "AccountUpdate::SUMMARY": Update Account
 "AccountUpdate::DESCRIPTION": Updates the properties and settings of your Account.
 "AccountUpdate::CALLBACK_URL": The URL that HelloSign should POST events to.
-"AccountUpdate::LOCALE": The locale used in this Account.
 
 "AccountVerify::SUMMARY": Verify Account
 "AccountVerify::DESCRIPTION": |-


### PR DESCRIPTION
Reverts hellosign/hellosign-openapi#36 so we can add guidance around accepted locales