### PR TITLE
Remove general team params from documentation but keep them in the SDK

### DIFF
--- a/bin/generate-sdk-oas.php
+++ b/bin/generate-sdk-oas.php
@@ -60,8 +60,8 @@ class GenerateSdkOas
     protected function loadOpenAPIFile(): void
     {
         $file = $this->language === 'en'
-            ? __DIR__ . '/../openapi.yaml'
-            : __DIR__ . "/../openapi-{$this->language}.yaml";
+            ? __DIR__ . '/../openapi-sdk-raw.yaml'
+            : __DIR__ . "/../openapi-sdk-raw-{$this->language}.yaml";
 
         if (!file_exists($file)) {
             throw new Exception(

--- a/bin/generate-sdk-oas.php
+++ b/bin/generate-sdk-oas.php
@@ -44,9 +44,10 @@ class GenerateSdkOas
 
     public function run(): void
     {
-        $this->loadOpenAPIFile();
+        $loaded_file = $this->loadOpenAPIFile();
         $this->remove();
         $this->saveOpenAPIFile();
+        unlink($loaded_file);
     }
 
     protected function remove(): void
@@ -55,9 +56,10 @@ class GenerateSdkOas
     }
 
     /**
-     * Load the OpenAPI YAML file, cast to array
+     * Load the OpenAPI YAML file, cast to array.
+     * Returns the path of the loaded file.
      */
-    protected function loadOpenAPIFile(): void
+    protected function loadOpenAPIFile(): string
     {
         $file = $this->language === 'en'
             ? __DIR__ . '/../openapi-sdk-raw.yaml'
@@ -70,6 +72,8 @@ class GenerateSdkOas
         }
 
         $this->openapi = Yaml::parse(file_get_contents($file));
+
+        return $file;
     }
 
     /**

--- a/bin/generate-translated-oas.php
+++ b/bin/generate-translated-oas.php
@@ -234,13 +234,7 @@ class GenerateOas
     protected function removeGeneralizedTeamParams(): void
     {
         // Remove team_id from /team/add_member query params
-        $team_id_index = array_search(
-            ['name' => 'team_id'],
-            $this->openapi['paths']['/team/add_member']['put']['parameters']
-        );
-        if ($team_id_index !== false) {
-            unset($this->openapi['paths']['/team/add_member']['put']['parameters'][$team_id_index]);
-        }
+        unset($this->openapi['paths']['/team/add_member']['put']['parameters'][0]);
 
         // Remove new_team_id, new_role from TeamRemoveMemberRequest
         unset(

--- a/bin/generate-translated-oas.php
+++ b/bin/generate-translated-oas.php
@@ -55,7 +55,7 @@ class GenerateOas
     protected array $openapi;
 
     /**
-     * Contains the OpenAPI spec for SDK, in array form
+     * Contains the raw OpenAPI spec for SDK, in array form
      *
      * @var array
      */
@@ -241,6 +241,12 @@ class GenerateOas
         if ($team_id_index !== false) {
             unset($this->openapi['paths']['/team/add_member']['put']['parameters'][$team_id_index]);
         }
+
+        // Remove new_team_id, new_role from TeamRemoveMemberRequest
+        unset(
+            $this->openapi['components']['schemas']['TeamRemoveMemberRequest']['properties']['new_team_id'],
+            $this->openapi['components']['schemas']['TeamRemoveMemberRequest']['properties']['new_role']
+        );
     }
 
     /**

--- a/bin/generate-translated-oas.php
+++ b/bin/generate-translated-oas.php
@@ -89,7 +89,8 @@ class GenerateOas
     public function run(): void
     {
         $this->loadOpenAPIFile();
-        $this->processOpenAPIFile();
+        $this->removeOneClickUrl();
+        $this->removeGeneralizedTeamParams();
         $this->loadTranslations();
 
         $this->openapi = $this->recurse($this->openapi);
@@ -220,12 +221,26 @@ class GenerateOas
         return $data;
     }
 
-    protected function processOpenAPIFile(): void
+    protected function removeOneClickUrl(): void
     {
         unset(
-            $this->openapi['paths']['/team/add_member']['put']['parameters'][0],
             $this->openapi['components']['schemas']['UnclaimedDraftResponse']['properties']['one_click_url'],
         );
+        unset(
+            $this->openapi_sdk_raw['components']['schemas']['UnclaimedDraftResponse']['properties']['one_click_url'],
+        );
+    }
+
+    protected function removeGeneralizedTeamParams(): void
+    {
+        // Remove team_id from /team/add_member query params
+        $team_id_index = array_search(
+            ['name' => 'team_id'],
+            $this->openapi['paths']['/team/add_member']['put']['parameters']
+        );
+        if ($team_id_index !== false) {
+            unset($this->openapi['paths']['/team/add_member']['put']['parameters'][$team_id_index]);
+        }
     }
 
     /**

--- a/bin/generate-translated-oas.php
+++ b/bin/generate-translated-oas.php
@@ -241,6 +241,13 @@ class GenerateOas
             $this->openapi['components']['schemas']['TeamRemoveMemberRequest']['properties']['new_team_id'],
             $this->openapi['components']['schemas']['TeamRemoveMemberRequest']['properties']['new_role']
         );
+
+        // Remove new endpoints
+        unset(
+            $this->openapi['paths']['/team/info'],
+            $this->openapi['paths']['/team/members/{team_id}'],
+            $this->openapi['paths']['/team/sub_teams/{team_id}'],
+        );
     }
 
     /**


### PR DESCRIPTION
We need a way to remove params from OpenApi Documentation while keeping the SDK aware of them.

My idea is to use 2 raw files, one for OpenAPI Documentation and one for the SDK. Just how `openapi.yaml` is produced from `openapi-raw.yaml` file, the `openapi-sdk.yaml` can be created from `openapi-sdk-raw.yaml` file.

That way we'll have a chance to customize them independently. 