### PR TITLE
Filter empty specs

### DIFF
--- a/src/Hello/OpenApi/RawFile.php
+++ b/src/Hello/OpenApi/RawFile.php
@@ -29,11 +29,6 @@ class RawFile
      */
     private const HIDE_ON = 'x-hideOn';
 
-    /**
-     * Key for openapi paths
-     */
-    private const PATHS = 'paths';
-
     private const PREPENDS = [
         self::TRANSLATE_PREPEND,
         self::MARKDOWN_PREPEND,
@@ -90,14 +85,11 @@ class RawFile
         $this->loadTranslations($translation_file, $fallback_file);
         $result = $this->recurse($this->openapi, $surface_id);
 
-        // Remove empty paths if any
-        $result[self::PATHS] = array_filter($result[self::PATHS]);
-
         $this->logs['translated'] = array_unique($this->logs['translated']);
         $this->logs['fallback'] = array_unique($this->logs['fallback']);
         $this->logs['untranslated'] = array_unique($this->logs['untranslated']);
 
-        return $result;
+        return $result->getData();
     }
 
     /**
@@ -140,16 +132,24 @@ class RawFile
      * to translate them.
      * @param array $data
      * @param string $surface_id
-     * @return array
+     * @return TranslationResult
      */
-    private function recurse(array $data, string $surface_id): array
+    private function recurse(array $data, string $surface_id): TranslationResult
     {
+        $empty_by_hiding = false;
+
         foreach ($data as $k => $v) {
             if (is_iterable($v)) {
                 if (isset($v[self::HIDE_ON]) && $v[self::HIDE_ON] === $surface_id) {
                     unset($data[$k]);
+                    $empty_by_hiding = empty($data);
                 } else {
-                    $data[$k] = $this->recurse($v, $surface_id);
+                    $result = $this->recurse($v, $surface_id);
+                    if ($result->isAllHidden()) {
+                        unset($data[$k]);
+                    } else {
+                        $data[$k] = $result->getData();
+                    }
                 }
 
                 continue;
@@ -190,7 +190,7 @@ class RawFile
             }
         }
 
-        return $data;
+        return new TranslationResult($data, $empty_by_hiding);
     }
 
     /**

--- a/src/Hello/OpenApi/RawFile.php
+++ b/src/Hello/OpenApi/RawFile.php
@@ -26,9 +26,13 @@ class RawFile
      * e.g.
      * x-hideOn: 'SDK'
      * x-hideOn: 'DOC'
-     * x-hideOn: 'NONE'
      */
     private const HIDE_ON = 'x-hideOn';
+
+    /**
+     * Key for openapi paths
+     */
+    private const PATHS = 'paths';
 
     private const PREPENDS = [
         self::TRANSLATE_PREPEND,
@@ -85,6 +89,9 @@ class RawFile
     ): array {
         $this->loadTranslations($translation_file, $fallback_file);
         $result = $this->recurse($this->openapi, $surface_id);
+
+        // Remove empty paths if any
+        $result[self::PATHS] = array_filter($result[self::PATHS]);
 
         $this->logs['translated'] = array_unique($this->logs['translated']);
         $this->logs['fallback'] = array_unique($this->logs['fallback']);

--- a/src/Hello/OpenApi/TranslationResult.php
+++ b/src/Hello/OpenApi/TranslationResult.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Hello\OpenApi;
+
+class TranslationResult
+{
+    /**
+     * Contains the OpenAPI spec, in array form
+     *
+     * @var array
+     */
+    private array $data;
+
+    /**
+     * Set to true if data is empty because everything was hidden.
+     *
+     * @var bool
+     */
+    public bool $all_hidden;
+
+    public function __construct(array $data, bool $all_hidden)
+    {
+        $this->data = $data;
+        $this->all_hidden = $all_hidden;
+    }
+
+    /**
+     * Returns data.
+     *
+     * @return array
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * Returns whether everything was hidden.
+     *
+     * @return bool
+     */
+    public function isAllHidden(): bool
+    {
+        return $this->all_hidden;
+    }
+}

--- a/src/Hello/OpenApi/TranslationResult.php
+++ b/src/Hello/OpenApi/TranslationResult.php
@@ -2,6 +2,13 @@
 
 namespace Hello\OpenApi;
 
+/**
+ * Represents a result of translating the openapi raw file.
+ * The all hidden flag is useful to unset empty collections which occur as a
+ * result of hiding all the spec within them.
+ *
+ * @see RawFile::translate()
+ */
 class TranslationResult
 {
     /**


### PR DESCRIPTION
If they become empty by hiding their elements using the `x-hideOn` directive.