### PR TITLE
Add CI workflow, push to any branch will trigger building SDKs and running unit tests

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,3 +38,16 @@ jobs:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           ref: openapi
           client_payload: '{"branch_name": "${{ github.ref_name }}"}'
+
+  trigger-java-sdk-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke downstream workflow
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: fenghao-chen
+          repo: hellosign-java-sdk
+          workflow_file_name: github-actions.yml
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: openapi
+          client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,4 +15,4 @@ jobs:
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
-        client_payload: "{'branch_name': ${{ github.ref }}}"
+        client_payload: "{'branch_name': $github.ref}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,16 +38,3 @@ jobs:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           ref: openapi
           client_payload: '{"branch_name": "${{ github.ref_name }}"}'
-
-  trigger-nodejs-sdk-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Invoke downstream workflow
-        uses: convictional/trigger-workflow-and-wait@v1.6.1
-        with:
-          owner: fenghao-chen
-          repo: hellosign-nodejs-sdk
-          workflow_file_name: github-actions.yml
-          github_token: ${{ secrets.PERSONAL_TOKEN }}
-          ref: openapi
-          client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -3,6 +3,10 @@ jobs:
   trigger-downstream-build:
     runs-on: ubuntu-latest
     steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
     - name: Invoke downstream workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,3 +15,4 @@ jobs:
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
+        client_payload: "{'branch_name': ${{ github.ref }}}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -51,3 +51,16 @@ jobs:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           ref: openapi
           client_payload: '{"branch_name": "${{ github.ref_name }}"}'
+
+  trigger-dotnet-sdk-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke downstream workflow
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: hellosign
+          repo: hellosign-dotnet-sdk
+          workflow_file_name: github-actions.yml
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: openapi
+          client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,4 +15,4 @@ jobs:
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
-        client_payload: '{"branch_name": "oas-release"}'
+        client_payload: '{"branch_name": "${{ github.ref }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -39,6 +39,19 @@ jobs:
           ref: openapi
           client_payload: '{"branch_name": "${{ github.ref_name }}"}'
 
+  trigger-nodejs-sdk-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke downstream workflow
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: HelloFax
+          repo: hellosign-nodejs-sdk
+          workflow_file_name: github-actions.yml
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: openapi
+          client_payload: '{"branch_name": "${{ github.ref_name }}"}'
+
   trigger-java-sdk-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+jobs:
+  trigger-downstream-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Invoke downstream workflow
+      uses: convictional/trigger-workflow-and-wait@v1.6.1
+      with:
+        workflow_file_name: github-actions.yml
+        repo: fenghao-chen/hellosign-php-sdk
+        token: ${{ secrets.PERSONAL_TOKEN }}
+        ref: openapi

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,7 +8,7 @@ jobs:
       with:
         owner: fenghao-chen
         repo: hellosign-php-sdk
-        workflow_file_name: github-actions.yml
+        workflow_file_name: triggered-by-upstream.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
         client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -12,3 +12,16 @@ jobs:
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
         client_payload: '{"branch_name": "${{ github.ref_name }}"}'
+
+  trigger-python-sdk-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke downstream workflow
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: fenghao-chen
+          repo: hellosign-python-sdk
+          workflow_file_name: github-actions.yml
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: openapi
+          client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,3 +38,16 @@ jobs:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           ref: openapi
           client_payload: '{"branch_name": "${{ github.ref_name }}"}'
+
+  trigger-nodejs-sdk-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke downstream workflow
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: fenghao-chen
+          repo: hellosign-nodejs-sdk
+          workflow_file_name: github-actions.yml
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: openapi
+          client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,12 +1,8 @@
-on: [push, pull_request]
+on: [pull_request]
 jobs:
-  trigger-downstream-build:
+  trigger-php-sdk-build:
     runs-on: ubuntu-latest
     steps:
-    - name: Git checkout
-      uses: actions/checkout@v1
-    - name: Branch name
-      run: echo running on branch ${GITHUB_REF##*/}
     - name: Invoke downstream workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,7 +6,7 @@ jobs:
     - name: Invoke downstream workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:
-        owner: fenghao-chen
+        owner: hellosign
         repo: hellosign-php-sdk
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
@@ -19,7 +19,7 @@ jobs:
       - name: Invoke downstream workflow
         uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          owner: fenghao-chen
+          owner: hellosign
           repo: hellosign-python-sdk
           workflow_file_name: github-actions.yml
           github_token: ${{ secrets.PERSONAL_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
       - name: Invoke downstream workflow
         uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          owner: fenghao-chen
+          owner: HelloFax
           repo: hellosign-ruby-sdk
           workflow_file_name: github-actions.yml
           github_token: ${{ secrets.PERSONAL_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
       - name: Invoke downstream workflow
         uses: convictional/trigger-workflow-and-wait@v1.6.1
         with:
-          owner: fenghao-chen
+          owner: hellosign
           repo: hellosign-java-sdk
           workflow_file_name: github-actions.yml
           github_token: ${{ secrets.PERSONAL_TOKEN }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,4 +15,4 @@ jobs:
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
-        client_payload: "{'branch_name': 'oas-release'}"
+        client_payload: '{"branch_name": "oas-release"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -6,7 +6,8 @@ jobs:
     - name: Invoke downstream workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:
+        owner: fenghao-chen
+        repo: hellosign-php-sdk
         workflow_file_name: github-actions.yml
-        repo: fenghao-chen/hellosign-php-sdk
-        token: ${{ secrets.PERSONAL_TOKEN }}
+        github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,4 +1,4 @@
-on: [pull_request]
+on: [push]
 jobs:
   trigger-php-sdk-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,7 +8,7 @@ jobs:
       with:
         owner: fenghao-chen
         repo: hellosign-php-sdk
-        workflow_file_name: triggered-by-upstream.yml
+        workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
         client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -25,3 +25,16 @@ jobs:
           github_token: ${{ secrets.PERSONAL_TOKEN }}
           ref: openapi
           client_payload: '{"branch_name": "${{ github.ref_name }}"}'
+
+  trigger-ruby-sdk-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke downstream workflow
+        uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: fenghao-chen
+          repo: hellosign-ruby-sdk
+          workflow_file_name: github-actions.yml
+          github_token: ${{ secrets.PERSONAL_TOKEN }}
+          ref: openapi
+          client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,4 +15,4 @@ jobs:
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
-        client_payload: '{"branch_name": "${{ github.ref }}"}'
+        client_payload: '{"branch_name": "${{ github.ref_name }}"}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -15,4 +15,4 @@ jobs:
         workflow_file_name: github-actions.yml
         github_token: ${{ secrets.PERSONAL_TOKEN }}
         ref: openapi
-        client_payload: "{'branch_name': $github.ref}"
+        client_payload: "{'branch_name': 'oas-release'}"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -3,10 +3,10 @@ jobs:
   trigger-downstream-build:
     runs-on: ubuntu-latest
     steps:
-    - name: Extract branch name
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
+    - name: Git checkout
+      uses: actions/checkout@v1
+    - name: Branch name
+      run: echo running on branch ${GITHUB_REF##*/}
     - name: Invoke downstream workflow
       uses: convictional/trigger-workflow-and-wait@v1.6.1
       with:


### PR DESCRIPTION
reminder to repo maintainer : add access token in `Repository secrets` so that github actions can check SDK workflow status.

Example of successful run: https://github.com/fenghao-chen/hellosign-openapi/actions/runs/2632390065