### PR TITLE
fix ruby gems name in examples

### DIFF
--- a/examples/AccountCreate.rb
+++ b/examples/AccountCreate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/AccountGet.rb
+++ b/examples/AccountGet.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/AccountUpdate.rb
+++ b/examples/AccountUpdate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/AccountVerify.rb
+++ b/examples/AccountVerify.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/ApiAppCreate.rb
+++ b/examples/ApiAppCreate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/ApiAppDelete.rb
+++ b/examples/ApiAppDelete.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/ApiAppGet.rb
+++ b/examples/ApiAppGet.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/ApiAppList.rb
+++ b/examples/ApiAppList.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/ApiAppUpdate.rb
+++ b/examples/ApiAppUpdate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/BulkSendJobGet.rb
+++ b/examples/BulkSendJobGet.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/BulkSendJobList.rb
+++ b/examples/BulkSendJobList.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/EmbeddedEditUrl.rb
+++ b/examples/EmbeddedEditUrl.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/EmbeddedSignUrl.rb
+++ b/examples/EmbeddedSignUrl.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/OauthTokenGenerate.rb
+++ b/examples/OauthTokenGenerate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/OauthTokenRefresh.rb
+++ b/examples/OauthTokenRefresh.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/ReportCreate.rb
+++ b/examples/ReportCreate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestBulkCreateEmbeddedWithTemplate.rb
+++ b/examples/SignatureRequestBulkCreateEmbeddedWithTemplate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestBulkSendWithTemplate.rb
+++ b/examples/SignatureRequestBulkSendWithTemplate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestCancel.rb
+++ b/examples/SignatureRequestCancel.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestCreateEmbedded.rb
+++ b/examples/SignatureRequestCreateEmbedded.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestCreateEmbeddedWithTemplate.rb
+++ b/examples/SignatureRequestCreateEmbeddedWithTemplate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestFiles.rb
+++ b/examples/SignatureRequestFiles.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestGet.rb
+++ b/examples/SignatureRequestGet.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestList.rb
+++ b/examples/SignatureRequestList.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestReleaseHold.rb
+++ b/examples/SignatureRequestReleaseHold.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestRemind.rb
+++ b/examples/SignatureRequestRemind.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestRemove.rb
+++ b/examples/SignatureRequestRemove.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestSend.rb
+++ b/examples/SignatureRequestSend.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestSendWithTemplate.rb
+++ b/examples/SignatureRequestSendWithTemplate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/SignatureRequestUpdate.rb
+++ b/examples/SignatureRequestUpdate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamAddMember.rb
+++ b/examples/TeamAddMember.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamCreate.rb
+++ b/examples/TeamCreate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamDelete.rb
+++ b/examples/TeamDelete.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamGet.rb
+++ b/examples/TeamGet.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamInfo.rb
+++ b/examples/TeamInfo.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamMembers.rb
+++ b/examples/TeamMembers.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamRemoveMember.rb
+++ b/examples/TeamRemoveMember.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamSubTeams.rb
+++ b/examples/TeamSubTeams.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TeamUpdate.rb
+++ b/examples/TeamUpdate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateAddUser.rb
+++ b/examples/TemplateAddUser.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateCreateEmbeddedDraft.rb
+++ b/examples/TemplateCreateEmbeddedDraft.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateDelete.rb
+++ b/examples/TemplateDelete.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateFiles.rb
+++ b/examples/TemplateFiles.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateGet.rb
+++ b/examples/TemplateGet.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateList.rb
+++ b/examples/TemplateList.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateRemoveUser.rb
+++ b/examples/TemplateRemoveUser.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/TemplateUpdateFiles.rb
+++ b/examples/TemplateUpdateFiles.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/UnclaimedDraftCreate.rb
+++ b/examples/UnclaimedDraftCreate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/UnclaimedDraftCreateEmbedded.rb
+++ b/examples/UnclaimedDraftCreateEmbedded.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/UnclaimedDraftCreateEmbeddedWithTemplate.rb
+++ b/examples/UnclaimedDraftCreateEmbeddedWithTemplate.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key

--- a/examples/UnclaimedDraftEditAndResend.rb
+++ b/examples/UnclaimedDraftEditAndResend.rb
@@ -1,4 +1,4 @@
-require "hello_sign"
+require "hellosign-ruby-sdk"
 
 HelloSign.configure do |config|
   # Configure HTTP basic authorization: api_key


### PR DESCRIPTION
Ruby gems name changed in https://github.com/HelloFax/hellosign-ruby-sdk/commit/e35ceeb7df5f42ad1b51c45d700214bab75ec2cf