### PR TITLE
fix jitpack.io issue for Java SDK

### DIFF
--- a/sdks/java/build.gradle
+++ b/sdks/java/build.gradle
@@ -27,7 +27,6 @@ repositories {
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
-    options.compilerArgs.addAll(['--release', '8']) // for java 8 cross-compilation
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/sdks/java/templates/libraries/jersey2/build.gradle.mustache
+++ b/sdks/java/templates/libraries/jersey2/build.gradle.mustache
@@ -27,7 +27,6 @@ repositories {
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
-    options.compilerArgs.addAll(['--release', '8']) // for java 8 cross-compilation
 }
 
 if (JavaVersion.current().isJava8Compatible()) {


### PR DESCRIPTION
I noticed JitPack.io stopped working since Sep 9, complaining `invalid flag: --release` https://jitpack.io/com/github/hellosign/hellosign-java-sdk/openapi-4.0.10-gf1df12d-59/build.log, causing sdk-tester fail to fetch the latest Java SDK version. Removing this line seems to fix the issue (https://jitpack.io/com/github/hellosign/hellosign-java-sdk/fix_jitpack_2-4.0.10-g21b1a13-70/build.log) 