### PR TITLE
Adding metadict via setup.py and setup.mustache 

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -23,6 +23,7 @@ VERSION = "6.0.0-beta22.23"
 REQUIRES = [
   "urllib3 >= 1.25.3",
   "python-dateutil",
+  "metadict",
 ]
 
 setup(

--- a/sdks/python/templates/setup.mustache
+++ b/sdks/python/templates/setup.mustache
@@ -17,6 +17,7 @@ VERSION = "{{packageVersion}}"
 REQUIRES = [
   "urllib3 >= 1.25.3",
   "python-dateutil",
+  "metadict",
 {{#asyncio}}
   "aiohttp >= 3.0.0",
 {{/asyncio}}


### PR DESCRIPTION
When installing the Python OpenAPI SDK via pip, you will need to install the metadict library to use the SDK as well. I have added the metadict via setup.py file and setup.mustache as a required installation. 

The changes in the pull request will install the metadict library as a dependency when installing the Python OpenAPI SDK via pip. 