### PR TITLE
Support default parameters for Java SDK

### DIFF
--- a/sdks/java/bin/replace
+++ b/sdks/java/bin/replace
@@ -19,7 +19,7 @@ rep () {
   set +e
   for i in "${SCAN_DIRS[@]}"
   do
-    perl -pi -e "s/${SEARCH_STRING}/${REPLACE_STRING}/g" \
+    perl -0pi -e "s/${SEARCH_STRING}/${REPLACE_STRING}/g" \
       "${ROOT_DIR}/${i}/"*.*
   done
 }
@@ -27,3 +27,4 @@ rep () {
 perl -pi -e 's/(.*)AllOf.md\)\n//g' "${ROOT_DIR}/README.md"
 
 rep 'import com.dropbox.sign.(.*)AllOf;\n' ''
+rep 'DUPLICATE_START(.*)DUPLICATE_END\n' ''

--- a/sdks/java/bin/replace
+++ b/sdks/java/bin/replace
@@ -25,6 +25,7 @@ rep () {
 }
 
 perl -pi -e 's/(.*)AllOf.md\)\n//g' "${ROOT_DIR}/README.md"
+perl -0pi -e 's/DUPLICATE_START(.*?)DUPLICATE_END\n//sg' "${ROOT_DIR}/src/main/java/com/dropbox/sign/api/"*.*
+
 
 rep 'import com.dropbox.sign.(.*)AllOf;\n' ''
-rep 'DUPLICATE_START(.*)DUPLICATE_END\n' ''

--- a/sdks/java/bin/replace
+++ b/sdks/java/bin/replace
@@ -19,7 +19,7 @@ rep () {
   set +e
   for i in "${SCAN_DIRS[@]}"
   do
-    perl -0pi -e "s/${SEARCH_STRING}/${REPLACE_STRING}/g" \
+    perl -pi -e "s/${SEARCH_STRING}/${REPLACE_STRING}/g" \
       "${ROOT_DIR}/${i}/"*.*
   done
 }

--- a/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
@@ -290,19 +290,19 @@ public class ApiAppApi {
 
     
   /**
-  * List API Apps
-  * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.
-  * @return ApiResponse&lt;ApiAppListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
+   * List API Apps
+   * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.
+   * @return ApiResponse&lt;ApiAppListResponse&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+     </table>
+   */
   public ApiResponse<ApiAppListResponse> apiAppListWithHttpInfo() throws ApiException {
-      return apiAppListWithHttpInfo(1, 20);
+    return apiAppListWithHttpInfo(1, 20);
   }
   
   /**

--- a/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
@@ -288,24 +288,7 @@ public class ApiAppApi {
     return apiAppListWithHttpInfo(page, pageSize).getData();
   }
 
-  DUPLICATE_START
-  /**
-  * List API Apps
-  * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.
-  * @return ApiResponse&lt;ApiAppListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<ApiAppListResponse> apiAppListWithHttpInfo() throws ApiException {
-      return apiAppListWithHttpInfo(1, 20);
-  }
-  DUPLICATE_END
-  
+    
   /**
   * List API Apps
   * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
@@ -288,6 +288,40 @@ public class ApiAppApi {
     return apiAppListWithHttpInfo(page, pageSize).getData();
   }
 
+  DUPLICATE_START
+  /**
+  * List API Apps
+  * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.
+  * @return ApiResponse&lt;ApiAppListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<ApiAppListResponse> apiAppListWithHttpInfo() throws ApiException {
+      return apiAppListWithHttpInfo(1, 20);
+  }
+  DUPLICATE_END
+  
+  /**
+  * List API Apps
+  * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.
+  * @return ApiResponse&lt;ApiAppListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<ApiAppListResponse> apiAppListWithHttpInfo() throws ApiException {
+      return apiAppListWithHttpInfo(1, 20);
+  }
+  
   /**
    * List API Apps
    * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/ApiAppApi.java
@@ -287,24 +287,28 @@ public class ApiAppApi {
   public ApiAppListResponse apiAppList(Integer page, Integer pageSize) throws ApiException {
     return apiAppListWithHttpInfo(page, pageSize).getData();
   }
-
     
   /**
-   * List API Apps
-   * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.
-   * @return ApiResponse&lt;ApiAppListResponse&gt;
-   * @throws ApiException if fails to make API call
-   * @http.response.details
-     <table summary="Response Details" border="1">
-       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-     </table>
+   * @see ApiAppApi#apiAppList(Integer, Integer)
+   */
+  public ApiAppListResponse apiAppList() throws ApiException {
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return apiAppListWithHttpInfo(page, pageSize).getData();
+  }
+
+  /**
+   * @see ApiAppApi#apiAppListWithHttpInfo(Integer, Integer)
    */
   public ApiResponse<ApiAppListResponse> apiAppListWithHttpInfo() throws ApiException {
-    return apiAppListWithHttpInfo(1, 20);
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return apiAppListWithHttpInfo(page, pageSize);
   }
   
+
   /**
    * List API Apps
    * Returns a list of API Apps that are accessible by you. If you are on a team with an Admin or Developer role, this list will include apps owned by teammates.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
@@ -142,19 +142,19 @@ public class BulkSendJobApi {
 
     
   /**
-  * List Bulk Send Jobs
-  * Returns a list of BulkSendJob that you can access.
-  * @return ApiResponse&lt;BulkSendJobListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
+   * List Bulk Send Jobs
+   * Returns a list of BulkSendJob that you can access.
+   * @return ApiResponse&lt;BulkSendJobListResponse&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+     </table>
+   */
   public ApiResponse<BulkSendJobListResponse> bulkSendJobListWithHttpInfo() throws ApiException {
-      return bulkSendJobListWithHttpInfo(1, 20);
+    return bulkSendJobListWithHttpInfo(1, 20);
   }
   
   /**

--- a/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
@@ -140,6 +140,40 @@ public class BulkSendJobApi {
     return bulkSendJobListWithHttpInfo(page, pageSize).getData();
   }
 
+  DUPLICATE_START
+  /**
+  * List Bulk Send Jobs
+  * Returns a list of BulkSendJob that you can access.
+  * @return ApiResponse&lt;BulkSendJobListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<BulkSendJobListResponse> bulkSendJobListWithHttpInfo() throws ApiException {
+      return bulkSendJobListWithHttpInfo(1, 20);
+  }
+  DUPLICATE_END
+  
+  /**
+  * List Bulk Send Jobs
+  * Returns a list of BulkSendJob that you can access.
+  * @return ApiResponse&lt;BulkSendJobListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<BulkSendJobListResponse> bulkSendJobListWithHttpInfo() throws ApiException {
+      return bulkSendJobListWithHttpInfo(1, 20);
+  }
+  
   /**
    * List Bulk Send Jobs
    * Returns a list of BulkSendJob that you can access.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
@@ -139,24 +139,28 @@ public class BulkSendJobApi {
   public BulkSendJobListResponse bulkSendJobList(Integer page, Integer pageSize) throws ApiException {
     return bulkSendJobListWithHttpInfo(page, pageSize).getData();
   }
-
     
   /**
-   * List Bulk Send Jobs
-   * Returns a list of BulkSendJob that you can access.
-   * @return ApiResponse&lt;BulkSendJobListResponse&gt;
-   * @throws ApiException if fails to make API call
-   * @http.response.details
-     <table summary="Response Details" border="1">
-       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-     </table>
+   * @see BulkSendJobApi#bulkSendJobList(Integer, Integer)
+   */
+  public BulkSendJobListResponse bulkSendJobList() throws ApiException {
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return bulkSendJobListWithHttpInfo(page, pageSize).getData();
+  }
+
+  /**
+   * @see BulkSendJobApi#bulkSendJobListWithHttpInfo(Integer, Integer)
    */
   public ApiResponse<BulkSendJobListResponse> bulkSendJobListWithHttpInfo() throws ApiException {
-    return bulkSendJobListWithHttpInfo(1, 20);
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return bulkSendJobListWithHttpInfo(page, pageSize);
   }
   
+
   /**
    * List Bulk Send Jobs
    * Returns a list of BulkSendJob that you can access.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/BulkSendJobApi.java
@@ -140,24 +140,7 @@ public class BulkSendJobApi {
     return bulkSendJobListWithHttpInfo(page, pageSize).getData();
   }
 
-  DUPLICATE_START
-  /**
-  * List Bulk Send Jobs
-  * Returns a list of BulkSendJob that you can access.
-  * @return ApiResponse&lt;BulkSendJobListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<BulkSendJobListResponse> bulkSendJobListWithHttpInfo() throws ApiException {
-      return bulkSendJobListWithHttpInfo(1, 20);
-  }
-  DUPLICATE_END
-  
+    
   /**
   * List Bulk Send Jobs
   * Returns a list of BulkSendJob that you can access.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -444,25 +444,26 @@ public class SignatureRequestApi {
   public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
   }
-
   
   /**
-   * Download Files
-   * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
-   * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
-   * @return ApiResponse&lt;File&gt;
-   * @throws ApiException if fails to make API call
-   * @http.response.details
-     <table summary="Response Details" border="1">
-       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-     </table>
+   * @see SignatureRequestApi#signatureRequestFiles(String, String)
+   */
+  public File signatureRequestFiles(String signatureRequestId) throws ApiException {
+    String fileType = "pdf";
+
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
+  }
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, "pdf");
+    String fileType = "pdf";
+
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
   }
   
+
   /**
    * Download Files
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
@@ -770,8 +771,8 @@ public class SignatureRequestApi {
   public SignatureRequestListResponse signatureRequestList(String accountId, Integer page, Integer pageSize, String query) throws ApiException {
     return signatureRequestListWithHttpInfo(accountId, page, pageSize, query).getData();
   }
-
-      /**
+    
+  /**
    * List Signature Requests
    * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.
    * @param accountId Which account to return SignatureRequests for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -771,45 +771,7 @@ public class SignatureRequestApi {
     return signatureRequestListWithHttpInfo(accountId, page, pageSize, query).getData();
   }
 
-  DUPLICATE_START
-  /**
-  * List Signature Requests
-  * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.
-      * @param accountId Which account to return SignatureRequests for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
-      * @param query String that includes search terms and/or fields to be used to filter the SignatureRequest objects. (optional)
-  * @return ApiResponse&lt;SignatureRequestListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<SignatureRequestListResponse> signatureRequestListWithHttpInfo(String accountId, String query) throws ApiException {
-      return signatureRequestListWithHttpInfo(accountId, 1, 20, query);
-  }
-  DUPLICATE_END
-  DUPLICATE_START
-  /**
-  * List Signature Requests
-  * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.
-      * @param accountId Which account to return SignatureRequests for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
-      * @param query String that includes search terms and/or fields to be used to filter the SignatureRequest objects. (optional)
-  * @return ApiResponse&lt;SignatureRequestListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<SignatureRequestListResponse> signatureRequestListWithHttpInfo(String accountId, String query) throws ApiException {
-      return signatureRequestListWithHttpInfo(accountId, 1, 20, query);
-  }
-  DUPLICATE_END
-  /**
+      /**
    * List Signature Requests
    * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.
    * @param accountId Which account to return SignatureRequests for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -445,6 +445,24 @@ public class SignatureRequestApi {
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
   }
 
+  
+  /**
+  * Download Files
+  * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
+      * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
+  * @return ApiResponse&lt;File&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
+      return signatureRequestFilesWithHttpInfo(signatureRequestId, "pdf");
+  }
+  
   /**
    * Download Files
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
@@ -753,6 +771,44 @@ public class SignatureRequestApi {
     return signatureRequestListWithHttpInfo(accountId, page, pageSize, query).getData();
   }
 
+  DUPLICATE_START
+  /**
+  * List Signature Requests
+  * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.
+      * @param accountId Which account to return SignatureRequests for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
+      * @param query String that includes search terms and/or fields to be used to filter the SignatureRequest objects. (optional)
+  * @return ApiResponse&lt;SignatureRequestListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<SignatureRequestListResponse> signatureRequestListWithHttpInfo(String accountId, String query) throws ApiException {
+      return signatureRequestListWithHttpInfo(accountId, 1, 20, query);
+  }
+  DUPLICATE_END
+  DUPLICATE_START
+  /**
+  * List Signature Requests
+  * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.
+      * @param accountId Which account to return SignatureRequests for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
+      * @param query String that includes search terms and/or fields to be used to filter the SignatureRequest objects. (optional)
+  * @return ApiResponse&lt;SignatureRequestListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<SignatureRequestListResponse> signatureRequestListWithHttpInfo(String accountId, String query) throws ApiException {
+      return signatureRequestListWithHttpInfo(accountId, 1, 20, query);
+  }
+  DUPLICATE_END
   /**
    * List Signature Requests
    * Returns a list of SignatureRequests that you can access. This includes SignatureRequests you have sent as well as received, but not ones that you have been CCed on.  Take a look at our [search guide](/api/reference/search/) to learn more about querying signature requests.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -447,20 +447,20 @@ public class SignatureRequestApi {
 
   
   /**
-  * Download Files
-  * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
-      * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
-  * @return ApiResponse&lt;File&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
+   * Download Files
+   * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
+   * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
+   * @return ApiResponse&lt;File&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+     </table>
+   */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
-      return signatureRequestFilesWithHttpInfo(signatureRequestId, "pdf");
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, "pdf");
   }
   
   /**

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
@@ -495,6 +495,42 @@ public class TeamApi {
     return teamMembersWithHttpInfo(teamId, page, pageSize).getData();
   }
 
+  DUPLICATE_START
+  /**
+  * List Team Members
+  * Provides a paginated list of members (and their roles) that belong to a given team.
+      * @param teamId The id of the team that a member list is being requested from. (required)
+  * @return ApiResponse&lt;TeamMembersResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<TeamMembersResponse> teamMembersWithHttpInfo(String teamId) throws ApiException {
+      return teamMembersWithHttpInfo(teamId, 1, 20);
+  }
+  DUPLICATE_END
+  
+  /**
+  * List Team Members
+  * Provides a paginated list of members (and their roles) that belong to a given team.
+      * @param teamId The id of the team that a member list is being requested from. (required)
+  * @return ApiResponse&lt;TeamMembersResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<TeamMembersResponse> teamMembersWithHttpInfo(String teamId) throws ApiException {
+      return teamMembersWithHttpInfo(teamId, 1, 20);
+  }
+  
   /**
    * List Team Members
    * Provides a paginated list of members (and their roles) that belong to a given team.
@@ -656,6 +692,42 @@ public class TeamApi {
     return teamSubTeamsWithHttpInfo(teamId, page, pageSize).getData();
   }
 
+  DUPLICATE_START
+  /**
+  * List Sub Teams
+  * Provides a paginated list of sub teams that belong to a given team.
+      * @param teamId The id of the parent Team. (required)
+  * @return ApiResponse&lt;TeamSubTeamsResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<TeamSubTeamsResponse> teamSubTeamsWithHttpInfo(String teamId) throws ApiException {
+      return teamSubTeamsWithHttpInfo(teamId, 1, 20);
+  }
+  DUPLICATE_END
+  
+  /**
+  * List Sub Teams
+  * Provides a paginated list of sub teams that belong to a given team.
+      * @param teamId The id of the parent Team. (required)
+  * @return ApiResponse&lt;TeamSubTeamsResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<TeamSubTeamsResponse> teamSubTeamsWithHttpInfo(String teamId) throws ApiException {
+      return teamSubTeamsWithHttpInfo(teamId, 1, 20);
+  }
+  
   /**
    * List Sub Teams
    * Provides a paginated list of sub teams that belong to a given team.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
@@ -494,25 +494,28 @@ public class TeamApi {
   public TeamMembersResponse teamMembers(String teamId, Integer page, Integer pageSize) throws ApiException {
     return teamMembersWithHttpInfo(teamId, page, pageSize).getData();
   }
-
     
   /**
-   * List Team Members
-   * Provides a paginated list of members (and their roles) that belong to a given team.
-   * @param teamId The id of the team that a member list is being requested from. (required)
-   * @return ApiResponse&lt;TeamMembersResponse&gt;
-   * @throws ApiException if fails to make API call
-   * @http.response.details
-     <table summary="Response Details" border="1">
-       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-     </table>
+   * @see TeamApi#teamMembers(String, Integer, Integer)
+   */
+  public TeamMembersResponse teamMembers(String teamId) throws ApiException {
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return teamMembersWithHttpInfo(teamId, page, pageSize).getData();
+  }
+
+  /**
+   * @see TeamApi#teamMembersWithHttpInfo(String, Integer, Integer)
    */
   public ApiResponse<TeamMembersResponse> teamMembersWithHttpInfo(String teamId) throws ApiException {
-    return teamMembersWithHttpInfo(teamId, 1, 20);
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return teamMembersWithHttpInfo(teamId, page, pageSize);
   }
   
+
   /**
    * List Team Members
    * Provides a paginated list of members (and their roles) that belong to a given team.
@@ -673,25 +676,28 @@ public class TeamApi {
   public TeamSubTeamsResponse teamSubTeams(String teamId, Integer page, Integer pageSize) throws ApiException {
     return teamSubTeamsWithHttpInfo(teamId, page, pageSize).getData();
   }
-
     
   /**
-   * List Sub Teams
-   * Provides a paginated list of sub teams that belong to a given team.
-   * @param teamId The id of the parent Team. (required)
-   * @return ApiResponse&lt;TeamSubTeamsResponse&gt;
-   * @throws ApiException if fails to make API call
-   * @http.response.details
-     <table summary="Response Details" border="1">
-       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-     </table>
+   * @see TeamApi#teamSubTeams(String, Integer, Integer)
+   */
+  public TeamSubTeamsResponse teamSubTeams(String teamId) throws ApiException {
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return teamSubTeamsWithHttpInfo(teamId, page, pageSize).getData();
+  }
+
+  /**
+   * @see TeamApi#teamSubTeamsWithHttpInfo(String, Integer, Integer)
    */
   public ApiResponse<TeamSubTeamsResponse> teamSubTeamsWithHttpInfo(String teamId) throws ApiException {
-    return teamSubTeamsWithHttpInfo(teamId, 1, 20);
+    Integer page = 1;
+    Integer pageSize = 20;
+
+    return teamSubTeamsWithHttpInfo(teamId, page, pageSize);
   }
   
+
   /**
    * List Sub Teams
    * Provides a paginated list of sub teams that belong to a given team.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
@@ -497,20 +497,20 @@ public class TeamApi {
 
     
   /**
-  * List Team Members
-  * Provides a paginated list of members (and their roles) that belong to a given team.
-      * @param teamId The id of the team that a member list is being requested from. (required)
-  * @return ApiResponse&lt;TeamMembersResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
+   * List Team Members
+   * Provides a paginated list of members (and their roles) that belong to a given team.
+   * @param teamId The id of the team that a member list is being requested from. (required)
+   * @return ApiResponse&lt;TeamMembersResponse&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+     </table>
+   */
   public ApiResponse<TeamMembersResponse> teamMembersWithHttpInfo(String teamId) throws ApiException {
-      return teamMembersWithHttpInfo(teamId, 1, 20);
+    return teamMembersWithHttpInfo(teamId, 1, 20);
   }
   
   /**
@@ -676,20 +676,20 @@ public class TeamApi {
 
     
   /**
-  * List Sub Teams
-  * Provides a paginated list of sub teams that belong to a given team.
-      * @param teamId The id of the parent Team. (required)
-  * @return ApiResponse&lt;TeamSubTeamsResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
+   * List Sub Teams
+   * Provides a paginated list of sub teams that belong to a given team.
+   * @param teamId The id of the parent Team. (required)
+   * @return ApiResponse&lt;TeamSubTeamsResponse&gt;
+   * @throws ApiException if fails to make API call
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+       <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+     </table>
+   */
   public ApiResponse<TeamSubTeamsResponse> teamSubTeamsWithHttpInfo(String teamId) throws ApiException {
-      return teamSubTeamsWithHttpInfo(teamId, 1, 20);
+    return teamSubTeamsWithHttpInfo(teamId, 1, 20);
   }
   
   /**

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TeamApi.java
@@ -495,25 +495,7 @@ public class TeamApi {
     return teamMembersWithHttpInfo(teamId, page, pageSize).getData();
   }
 
-  DUPLICATE_START
-  /**
-  * List Team Members
-  * Provides a paginated list of members (and their roles) that belong to a given team.
-      * @param teamId The id of the team that a member list is being requested from. (required)
-  * @return ApiResponse&lt;TeamMembersResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<TeamMembersResponse> teamMembersWithHttpInfo(String teamId) throws ApiException {
-      return teamMembersWithHttpInfo(teamId, 1, 20);
-  }
-  DUPLICATE_END
-  
+    
   /**
   * List Team Members
   * Provides a paginated list of members (and their roles) that belong to a given team.
@@ -692,25 +674,7 @@ public class TeamApi {
     return teamSubTeamsWithHttpInfo(teamId, page, pageSize).getData();
   }
 
-  DUPLICATE_START
-  /**
-  * List Sub Teams
-  * Provides a paginated list of sub teams that belong to a given team.
-      * @param teamId The id of the parent Team. (required)
-  * @return ApiResponse&lt;TeamSubTeamsResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<TeamSubTeamsResponse> teamSubTeamsWithHttpInfo(String teamId) throws ApiException {
-      return teamSubTeamsWithHttpInfo(teamId, 1, 20);
-  }
-  DUPLICATE_END
-  
+    
   /**
   * List Sub Teams
   * Provides a paginated list of sub teams that belong to a given team.

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -606,8 +606,8 @@ public class TemplateApi {
   public TemplateListResponse templateList(String accountId, Integer page, Integer pageSize, String query) throws ApiException {
     return templateListWithHttpInfo(accountId, page, pageSize, query).getData();
   }
-
-      /**
+    
+  /**
    * List Templates
    * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.
    * @param accountId Which account to return Templates for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -607,45 +607,7 @@ public class TemplateApi {
     return templateListWithHttpInfo(accountId, page, pageSize, query).getData();
   }
 
-  DUPLICATE_START
-  /**
-  * List Templates
-  * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.
-      * @param accountId Which account to return Templates for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
-      * @param query String that includes search terms and/or fields to be used to filter the Template objects. (optional)
-  * @return ApiResponse&lt;TemplateListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<TemplateListResponse> templateListWithHttpInfo(String accountId, String query) throws ApiException {
-      return templateListWithHttpInfo(accountId, 1, 20, query);
-  }
-  DUPLICATE_END
-  DUPLICATE_START
-  /**
-  * List Templates
-  * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.
-      * @param accountId Which account to return Templates for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
-      * @param query String that includes search terms and/or fields to be used to filter the Template objects. (optional)
-  * @return ApiResponse&lt;TemplateListResponse&gt;
-  * @throws ApiException if fails to make API call
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
-              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
-      </table>
-  */
-  public ApiResponse<TemplateListResponse> templateListWithHttpInfo(String accountId, String query) throws ApiException {
-      return templateListWithHttpInfo(accountId, 1, 20, query);
-  }
-  DUPLICATE_END
-  /**
+      /**
    * List Templates
    * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.
    * @param accountId Which account to return Templates for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -607,6 +607,44 @@ public class TemplateApi {
     return templateListWithHttpInfo(accountId, page, pageSize, query).getData();
   }
 
+  DUPLICATE_START
+  /**
+  * List Templates
+  * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.
+      * @param accountId Which account to return Templates for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
+      * @param query String that includes search terms and/or fields to be used to filter the Template objects. (optional)
+  * @return ApiResponse&lt;TemplateListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<TemplateListResponse> templateListWithHttpInfo(String accountId, String query) throws ApiException {
+      return templateListWithHttpInfo(accountId, 1, 20, query);
+  }
+  DUPLICATE_END
+  DUPLICATE_START
+  /**
+  * List Templates
+  * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.
+      * @param accountId Which account to return Templates for. Must be a team member. Use &#x60;all&#x60; to indicate all team members. Defaults to your account. (optional)
+      * @param query String that includes search terms and/or fields to be used to filter the Template objects. (optional)
+  * @return ApiResponse&lt;TemplateListResponse&gt;
+  * @throws ApiException if fails to make API call
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+              <tr><td> 200 </td><td> successful operation </td><td>  * X-RateLimit-Limit -  <br>  * X-RateLimit-Remaining -  <br>  * X-Ratelimit-Reset -  <br>  </td></tr>
+              <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
+      </table>
+  */
+  public ApiResponse<TemplateListResponse> templateListWithHttpInfo(String accountId, String query) throws ApiException {
+      return templateListWithHttpInfo(accountId, 1, 20, query);
+  }
+  DUPLICATE_END
   /**
    * List Templates
    * Returns a list of the Templates that are accessible by you.  Take a look at our [search guide](/api/reference/search/) to learn more about querying templates.

--- a/sdks/java/templates/libraries/jersey2/api.mustache
+++ b/sdks/java/templates/libraries/jersey2/api.mustache
@@ -87,13 +87,45 @@ public class {{classname}} {
   {{/vendorExtensions.x-group-parameters}}
 
   {{#allParams}}
-      {{#defaultValue}}
-  public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
-      return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
-  }
+  {{#defaultValue}}
+  {{^-last}}DUPLICATE_START{{/-last}}
+  {{^vendorExtensions.x-group-parameters}}
+  /**
+  * {{summary}}
+  * {{notes}}
+  {{#allParams}}
+      {{^defaultValue}}
+      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
       {{/defaultValue}}
   {{/allParams}}
-
+  * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
+  * @throws ApiException if fails to make API call
+  {{#responses.0}}
+      * @http.response.details
+      <table summary="Response Details" border="1">
+          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+          {{#responses}}
+              <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+          {{/responses}}
+      </table>
+  {{/responses.0}}
+  {{#isDeprecated}}
+      * @deprecated
+  {{/isDeprecated}}
+  {{#externalDocs}}
+      * {{description}}
+      * @see <a href="{{url}}">{{summary}} Documentation</a>
+  {{/externalDocs}}
+  */
+  {{#isDeprecated}}
+      @Deprecated
+  {{/isDeprecated}}
+  public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
+      return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
+  }
+  {{^-last}}DUPLICATE_END{{/-last}}
+  {{/defaultValue}}
+  {{/allParams}}
   {{^vendorExtensions.x-group-parameters}}
   /**
    * {{summary}}

--- a/sdks/java/templates/libraries/jersey2/api.mustache
+++ b/sdks/java/templates/libraries/jersey2/api.mustache
@@ -86,6 +86,14 @@ public class {{classname}} {
   }
   {{/vendorExtensions.x-group-parameters}}
 
+  {{#allParams}}
+      {{#defaultValue}}
+          public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
+              return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
+          }
+      {{/defaultValue}}
+  {{/allParams}}
+
   {{^vendorExtensions.x-group-parameters}}
   /**
    * {{summary}}

--- a/sdks/java/templates/libraries/jersey2/api.mustache
+++ b/sdks/java/templates/libraries/jersey2/api.mustache
@@ -85,47 +85,44 @@ public class {{classname}} {
     {{#returnType}}return {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}){{#returnType}}.getData(){{/returnType}};
   }
   {{/vendorExtensions.x-group-parameters}}
-
   {{#allParams}}
   {{#defaultValue}}
   {{^-last}}DUPLICATE_START{{/-last}}
-  {{^vendorExtensions.x-group-parameters}}
   /**
-   * {{summary}}
-   * {{notes}}
-   {{#allParams}}
-   {{^defaultValue}}
-   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
-   {{/defaultValue}}
-   {{/allParams}}
-   * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
-   * @throws ApiException if fails to make API call
-   {{#responses.0}}
-   * @http.response.details
-     <table summary="Response Details" border="1">
-       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-       {{#responses}}
-       <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
-       {{/responses}}
-     </table>
-   {{/responses.0}}
-   {{#isDeprecated}}
-   * @deprecated
-   {{/isDeprecated}}
-   {{#externalDocs}}
-   * {{description}}
-   * @see <a href="{{url}}">{{summary}} Documentation</a>
-   {{/externalDocs}}
+   * @see {{classname}}#{{operationId}}({{#allParams}}{{{dataType}}}{{^-last}}, {{/-last}}{{/allParams}})
    */
   {{#isDeprecated}}
   @Deprecated
   {{/isDeprecated}}
-  public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
-    return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
+  public {{#returnType}}{{{.}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
+    {{#allParams}}
+    {{#defaultValue}}
+    {{{dataType}}} {{paramName}} = {{#isString}}"{{/isString}}{{{.}}}{{#isString}}"{{/isString}};
+    {{/defaultValue}}
+    {{/allParams}}
+
+    {{#returnType}}return {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}){{#returnType}}.getData(){{/returnType}};
+  }
+
+  /**
+   * @see {{classname}}#{{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}}{{^-last}}, {{/-last}}{{/allParams}})
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public ApiResponse<{{returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
+    {{#allParams}}
+    {{#defaultValue}}
+    {{{dataType}}} {{paramName}} = {{#isString}}"{{/isString}}{{{.}}}{{#isString}}"{{/isString}};
+    {{/defaultValue}}
+    {{/allParams}}
+
+    {{#returnType}}return {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
   }
   {{^-last}}DUPLICATE_END{{/-last}}
   {{/defaultValue}}
   {{/allParams}}
+
   {{^vendorExtensions.x-group-parameters}}
   /**
    * {{summary}}

--- a/sdks/java/templates/libraries/jersey2/api.mustache
+++ b/sdks/java/templates/libraries/jersey2/api.mustache
@@ -91,37 +91,37 @@ public class {{classname}} {
   {{^-last}}DUPLICATE_START{{/-last}}
   {{^vendorExtensions.x-group-parameters}}
   /**
-  * {{summary}}
-  * {{notes}}
-  {{#allParams}}
-      {{^defaultValue}}
-      * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
-      {{/defaultValue}}
-  {{/allParams}}
-  * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
-  * @throws ApiException if fails to make API call
-  {{#responses.0}}
-      * @http.response.details
-      <table summary="Response Details" border="1">
-          <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
-          {{#responses}}
-              <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
-          {{/responses}}
-      </table>
-  {{/responses.0}}
+   * {{summary}}
+   * {{notes}}
+   {{#allParams}}
+   {{^defaultValue}}
+   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+   {{/defaultValue}}
+   {{/allParams}}
+   * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
+   * @throws ApiException if fails to make API call
+   {{#responses.0}}
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       {{#responses}}
+       <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+       {{/responses}}
+     </table>
+   {{/responses.0}}
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
   {{#isDeprecated}}
-      * @deprecated
-  {{/isDeprecated}}
-  {{#externalDocs}}
-      * {{description}}
-      * @see <a href="{{url}}">{{summary}} Documentation</a>
-  {{/externalDocs}}
-  */
-  {{#isDeprecated}}
-      @Deprecated
+  @Deprecated
   {{/isDeprecated}}
   public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{returnType}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
-      return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
+    return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
   }
   {{^-last}}DUPLICATE_END{{/-last}}
   {{/defaultValue}}

--- a/sdks/java/templates/libraries/jersey2/api.mustache
+++ b/sdks/java/templates/libraries/jersey2/api.mustache
@@ -88,9 +88,9 @@ public class {{classname}} {
 
   {{#allParams}}
       {{#defaultValue}}
-          public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
-              return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
-          }
+  public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{{dataType}}} {{paramName}}{{/defaultValue}}{{/allParams}}) throws ApiException {
+      return {{operationId}}WithHttpInfo({{#allParams}}{{^defaultValue}}{{^-first}}, {{/-first}}{{paramName}}{{/defaultValue}}{{#defaultValue}}{{^-first}}, {{/-first}}{{#isString}}"{{/isString}}{{{defaultValue}}}{{#isString}}"{{/isString}}{{/defaultValue}}{{/allParams}});
+  }
       {{/defaultValue}}
   {{/allParams}}
 


### PR DESCRIPTION
The default parameters must appear after other required & non-default parameters of the method signature, otherwise the method won't be generated  