### PR TITLE
Allow running native PHP vs docker

### DIFF
--- a/sdks/php/bin/php
+++ b/sdks/php/bin/php
@@ -8,9 +8,17 @@ DIR=$(cd `dirname $0` && pwd)
 ROOT_DIR="${DIR}/.."
 WORKING_DIR="/app/php"
 
-docker run --rm \
-  -v "${ROOT_DIR}:${WORKING_DIR}" \
-  -v "dropbox-sign-sdk-composer-cache:/.composer" \
-  -w "${WORKING_DIR}" \
-  -u root:root \
-  jtreminio/php-cli:7.4 "$@"
+if [[ -z "$PHP_USE_NATIVE" ]]; then
+  docker run --rm \
+    -v "${ROOT_DIR}:${WORKING_DIR}" \
+    -v "dropbox-sign-sdk-composer-cache:/.composer" \
+    -w "${WORKING_DIR}" \
+    -u root:root \
+    jtreminio/php-cli:7.4 "$@"
+
+    exit 0
+fi
+
+pushd "${ROOT_DIR}"
+exec "$@"
+popd

--- a/sdks/php/src/Model/AccountCreateRequest.php
+++ b/sdks/php/src/Model/AccountCreateRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountCreateRequest Class Doc Comment
@@ -346,7 +347,7 @@ class AccountCreateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -359,7 +360,7 @@ class AccountCreateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -373,7 +374,7 @@ class AccountCreateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -390,7 +391,7 @@ class AccountCreateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -403,7 +404,7 @@ class AccountCreateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountCreateResponse.php
+++ b/sdks/php/src/Model/AccountCreateResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountCreateResponse Class Doc Comment
@@ -313,7 +314,7 @@ class AccountCreateResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class AccountCreateResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class AccountCreateResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class AccountCreateResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class AccountCreateResponse implements ModelInterface, ArrayAccess, JsonSerializ
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountGetResponse.php
+++ b/sdks/php/src/Model/AccountGetResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountGetResponse Class Doc Comment
@@ -283,7 +284,7 @@ class AccountGetResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class AccountGetResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class AccountGetResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class AccountGetResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class AccountGetResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountResponse.php
+++ b/sdks/php/src/Model/AccountResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountResponse Class Doc Comment
@@ -523,7 +524,7 @@ class AccountResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -536,7 +537,7 @@ class AccountResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -550,7 +551,7 @@ class AccountResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -567,7 +568,7 @@ class AccountResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -580,7 +581,7 @@ class AccountResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountResponseQuotas.php
+++ b/sdks/php/src/Model/AccountResponseQuotas.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountResponseQuotas Class Doc Comment
@@ -374,7 +375,7 @@ class AccountResponseQuotas implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -387,7 +388,7 @@ class AccountResponseQuotas implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -401,7 +402,7 @@ class AccountResponseQuotas implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -418,7 +419,7 @@ class AccountResponseQuotas implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -431,7 +432,7 @@ class AccountResponseQuotas implements ModelInterface, ArrayAccess, JsonSerializ
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountUpdateRequest.php
+++ b/sdks/php/src/Model/AccountUpdateRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountUpdateRequest Class Doc Comment
@@ -312,7 +313,7 @@ class AccountUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -325,7 +326,7 @@ class AccountUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -339,7 +340,7 @@ class AccountUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -356,7 +357,7 @@ class AccountUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -369,7 +370,7 @@ class AccountUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountVerifyRequest.php
+++ b/sdks/php/src/Model/AccountVerifyRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountVerifyRequest Class Doc Comment
@@ -256,7 +257,7 @@ class AccountVerifyRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -269,7 +270,7 @@ class AccountVerifyRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -283,7 +284,7 @@ class AccountVerifyRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -300,7 +301,7 @@ class AccountVerifyRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -313,7 +314,7 @@ class AccountVerifyRequest implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountVerifyResponse.php
+++ b/sdks/php/src/Model/AccountVerifyResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountVerifyResponse Class Doc Comment
@@ -283,7 +284,7 @@ class AccountVerifyResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class AccountVerifyResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class AccountVerifyResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class AccountVerifyResponse implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class AccountVerifyResponse implements ModelInterface, ArrayAccess, JsonSerializ
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/AccountVerifyResponseAccount.php
+++ b/sdks/php/src/Model/AccountVerifyResponseAccount.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * AccountVerifyResponseAccount Class Doc Comment
@@ -253,7 +254,7 @@ class AccountVerifyResponseAccount implements ModelInterface, ArrayAccess, JsonS
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -266,7 +267,7 @@ class AccountVerifyResponseAccount implements ModelInterface, ArrayAccess, JsonS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -280,7 +281,7 @@ class AccountVerifyResponseAccount implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -297,7 +298,7 @@ class AccountVerifyResponseAccount implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -310,7 +311,7 @@ class AccountVerifyResponseAccount implements ModelInterface, ArrayAccess, JsonS
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppCreateRequest.php
+++ b/sdks/php/src/Model/ApiAppCreateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -455,7 +456,7 @@ class ApiAppCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -468,7 +469,7 @@ class ApiAppCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -482,7 +483,7 @@ class ApiAppCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -499,7 +500,7 @@ class ApiAppCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -512,7 +513,7 @@ class ApiAppCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppGetResponse.php
+++ b/sdks/php/src/Model/ApiAppGetResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppGetResponse Class Doc Comment
@@ -283,7 +284,7 @@ class ApiAppGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class ApiAppGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class ApiAppGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class ApiAppGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class ApiAppGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppListResponse.php
+++ b/sdks/php/src/Model/ApiAppListResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppListResponse Class Doc Comment
@@ -313,7 +314,7 @@ class ApiAppListResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class ApiAppListResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class ApiAppListResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class ApiAppListResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class ApiAppListResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppResponse.php
+++ b/sdks/php/src/Model/ApiAppResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppResponse Class Doc Comment
@@ -524,7 +525,7 @@ class ApiAppResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -537,7 +538,7 @@ class ApiAppResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -551,7 +552,7 @@ class ApiAppResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -568,7 +569,7 @@ class ApiAppResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -581,7 +582,7 @@ class ApiAppResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppResponseOAuth.php
+++ b/sdks/php/src/Model/ApiAppResponseOAuth.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppResponseOAuth Class Doc Comment
@@ -344,7 +345,7 @@ class ApiAppResponseOAuth implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -357,7 +358,7 @@ class ApiAppResponseOAuth implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -371,7 +372,7 @@ class ApiAppResponseOAuth implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -388,7 +389,7 @@ class ApiAppResponseOAuth implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -401,7 +402,7 @@ class ApiAppResponseOAuth implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppResponseOptions.php
+++ b/sdks/php/src/Model/ApiAppResponseOptions.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppResponseOptions Class Doc Comment
@@ -254,7 +255,7 @@ class ApiAppResponseOptions implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -267,7 +268,7 @@ class ApiAppResponseOptions implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -281,7 +282,7 @@ class ApiAppResponseOptions implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -298,7 +299,7 @@ class ApiAppResponseOptions implements ModelInterface, ArrayAccess, JsonSerializ
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -311,7 +312,7 @@ class ApiAppResponseOptions implements ModelInterface, ArrayAccess, JsonSerializ
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppResponseOwnerAccount.php
+++ b/sdks/php/src/Model/ApiAppResponseOwnerAccount.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppResponseOwnerAccount Class Doc Comment
@@ -284,7 +285,7 @@ class ApiAppResponseOwnerAccount implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class ApiAppResponseOwnerAccount implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class ApiAppResponseOwnerAccount implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class ApiAppResponseOwnerAccount implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class ApiAppResponseOwnerAccount implements ModelInterface, ArrayAccess, JsonSer
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppResponseWhiteLabelingOptions.php
+++ b/sdks/php/src/Model/ApiAppResponseWhiteLabelingOptions.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ApiAppResponseWhiteLabelingOptions Class Doc Comment
@@ -644,7 +645,7 @@ class ApiAppResponseWhiteLabelingOptions implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -657,7 +658,7 @@ class ApiAppResponseWhiteLabelingOptions implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -671,7 +672,7 @@ class ApiAppResponseWhiteLabelingOptions implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -688,7 +689,7 @@ class ApiAppResponseWhiteLabelingOptions implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -701,7 +702,7 @@ class ApiAppResponseWhiteLabelingOptions implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ApiAppUpdateRequest.php
+++ b/sdks/php/src/Model/ApiAppUpdateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -441,7 +442,7 @@ class ApiAppUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -454,7 +455,7 @@ class ApiAppUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -468,7 +469,7 @@ class ApiAppUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -485,7 +486,7 @@ class ApiAppUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -498,7 +499,7 @@ class ApiAppUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/BulkSendJobGetResponse.php
+++ b/sdks/php/src/Model/BulkSendJobGetResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * BulkSendJobGetResponse Class Doc Comment
@@ -343,7 +344,7 @@ class BulkSendJobGetResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -356,7 +357,7 @@ class BulkSendJobGetResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -370,7 +371,7 @@ class BulkSendJobGetResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -387,7 +388,7 @@ class BulkSendJobGetResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -400,7 +401,7 @@ class BulkSendJobGetResponse implements ModelInterface, ArrayAccess, JsonSeriali
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/BulkSendJobGetResponseSignatureRequests.php
+++ b/sdks/php/src/Model/BulkSendJobGetResponseSignatureRequests.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * BulkSendJobGetResponseSignatureRequests Class Doc Comment
@@ -943,7 +944,7 @@ class BulkSendJobGetResponseSignatureRequests implements ModelInterface, ArrayAc
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -956,7 +957,7 @@ class BulkSendJobGetResponseSignatureRequests implements ModelInterface, ArrayAc
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -970,7 +971,7 @@ class BulkSendJobGetResponseSignatureRequests implements ModelInterface, ArrayAc
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -987,7 +988,7 @@ class BulkSendJobGetResponseSignatureRequests implements ModelInterface, ArrayAc
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1000,7 +1001,7 @@ class BulkSendJobGetResponseSignatureRequests implements ModelInterface, ArrayAc
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/BulkSendJobListResponse.php
+++ b/sdks/php/src/Model/BulkSendJobListResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * BulkSendJobListResponse Class Doc Comment
@@ -313,7 +314,7 @@ class BulkSendJobListResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class BulkSendJobListResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class BulkSendJobListResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class BulkSendJobListResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class BulkSendJobListResponse implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/BulkSendJobResponse.php
+++ b/sdks/php/src/Model/BulkSendJobResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * BulkSendJobResponse Class Doc Comment
@@ -344,7 +345,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -357,7 +358,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -371,7 +372,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -388,7 +389,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -401,7 +402,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/BulkSendJobSendResponse.php
+++ b/sdks/php/src/Model/BulkSendJobSendResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * BulkSendJobSendResponse Class Doc Comment
@@ -283,7 +284,7 @@ class BulkSendJobSendResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class BulkSendJobSendResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class BulkSendJobSendResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class BulkSendJobSendResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class BulkSendJobSendResponse implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EmbeddedEditUrlRequest.php
+++ b/sdks/php/src/Model/EmbeddedEditUrlRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EmbeddedEditUrlRequest Class Doc Comment
@@ -522,7 +523,7 @@ class EmbeddedEditUrlRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -535,7 +536,7 @@ class EmbeddedEditUrlRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -549,7 +550,7 @@ class EmbeddedEditUrlRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -566,7 +567,7 @@ class EmbeddedEditUrlRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -579,7 +580,7 @@ class EmbeddedEditUrlRequest implements ModelInterface, ArrayAccess, JsonSeriali
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EmbeddedEditUrlResponse.php
+++ b/sdks/php/src/Model/EmbeddedEditUrlResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EmbeddedEditUrlResponse Class Doc Comment
@@ -283,7 +284,7 @@ class EmbeddedEditUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class EmbeddedEditUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class EmbeddedEditUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class EmbeddedEditUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class EmbeddedEditUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EmbeddedEditUrlResponseEmbedded.php
+++ b/sdks/php/src/Model/EmbeddedEditUrlResponseEmbedded.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EmbeddedEditUrlResponseEmbedded Class Doc Comment
@@ -284,7 +285,7 @@ class EmbeddedEditUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class EmbeddedEditUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class EmbeddedEditUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class EmbeddedEditUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class EmbeddedEditUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EmbeddedSignUrlResponse.php
+++ b/sdks/php/src/Model/EmbeddedSignUrlResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EmbeddedSignUrlResponse Class Doc Comment
@@ -283,7 +284,7 @@ class EmbeddedSignUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class EmbeddedSignUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class EmbeddedSignUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class EmbeddedSignUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class EmbeddedSignUrlResponse implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EmbeddedSignUrlResponseEmbedded.php
+++ b/sdks/php/src/Model/EmbeddedSignUrlResponseEmbedded.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EmbeddedSignUrlResponseEmbedded Class Doc Comment
@@ -284,7 +285,7 @@ class EmbeddedSignUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class EmbeddedSignUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class EmbeddedSignUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class EmbeddedSignUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class EmbeddedSignUrlResponseEmbedded implements ModelInterface, ArrayAccess, Js
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ErrorResponse.php
+++ b/sdks/php/src/Model/ErrorResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ErrorResponse Class Doc Comment
@@ -256,7 +257,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -269,7 +270,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -283,7 +284,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -300,7 +301,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -313,7 +314,7 @@ class ErrorResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ErrorResponseError.php
+++ b/sdks/php/src/Model/ErrorResponseError.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ErrorResponseError Class Doc Comment
@@ -320,7 +321,7 @@ class ErrorResponseError implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -333,7 +334,7 @@ class ErrorResponseError implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -347,7 +348,7 @@ class ErrorResponseError implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,7 +365,7 @@ class ErrorResponseError implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -377,7 +378,7 @@ class ErrorResponseError implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EventCallbackRequest.php
+++ b/sdks/php/src/Model/EventCallbackRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EventCallbackRequest Class Doc Comment
@@ -346,7 +347,7 @@ class EventCallbackRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -359,7 +360,7 @@ class EventCallbackRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -373,7 +374,7 @@ class EventCallbackRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -390,7 +391,7 @@ class EventCallbackRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -403,7 +404,7 @@ class EventCallbackRequest implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EventCallbackRequestEvent.php
+++ b/sdks/php/src/Model/EventCallbackRequestEvent.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EventCallbackRequestEvent Class Doc Comment
@@ -432,7 +433,7 @@ class EventCallbackRequestEvent implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -445,7 +446,7 @@ class EventCallbackRequestEvent implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -459,7 +460,7 @@ class EventCallbackRequestEvent implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -476,7 +477,7 @@ class EventCallbackRequestEvent implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -489,7 +490,7 @@ class EventCallbackRequestEvent implements ModelInterface, ArrayAccess, JsonSeri
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/EventCallbackRequestEventMetadata.php
+++ b/sdks/php/src/Model/EventCallbackRequestEventMetadata.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * EventCallbackRequestEventMetadata Class Doc Comment
@@ -343,7 +344,7 @@ class EventCallbackRequestEventMetadata implements ModelInterface, ArrayAccess, 
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -356,7 +357,7 @@ class EventCallbackRequestEventMetadata implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -370,7 +371,7 @@ class EventCallbackRequestEventMetadata implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -387,7 +388,7 @@ class EventCallbackRequestEventMetadata implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -400,7 +401,7 @@ class EventCallbackRequestEventMetadata implements ModelInterface, ArrayAccess, 
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/FileResponse.php
+++ b/sdks/php/src/Model/FileResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * FileResponse Class Doc Comment
@@ -283,7 +284,7 @@ class FileResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class FileResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class FileResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class FileResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class FileResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/FileResponseDataUri.php
+++ b/sdks/php/src/Model/FileResponseDataUri.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * FileResponseDataUri Class Doc Comment
@@ -253,7 +254,7 @@ class FileResponseDataUri implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -266,7 +267,7 @@ class FileResponseDataUri implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -280,7 +281,7 @@ class FileResponseDataUri implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -297,7 +298,7 @@ class FileResponseDataUri implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -310,7 +311,7 @@ class FileResponseDataUri implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ListInfoResponse.php
+++ b/sdks/php/src/Model/ListInfoResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ListInfoResponse Class Doc Comment
@@ -344,7 +345,7 @@ class ListInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -357,7 +358,7 @@ class ListInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -371,7 +372,7 @@ class ListInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -388,7 +389,7 @@ class ListInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -401,7 +402,7 @@ class ListInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/OAuthTokenGenerateRequest.php
+++ b/sdks/php/src/Model/OAuthTokenGenerateRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * OAuthTokenGenerateRequest Class Doc Comment
@@ -388,7 +389,7 @@ class OAuthTokenGenerateRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -401,7 +402,7 @@ class OAuthTokenGenerateRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -415,7 +416,7 @@ class OAuthTokenGenerateRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -432,7 +433,7 @@ class OAuthTokenGenerateRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -445,7 +446,7 @@ class OAuthTokenGenerateRequest implements ModelInterface, ArrayAccess, JsonSeri
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/OAuthTokenRefreshRequest.php
+++ b/sdks/php/src/Model/OAuthTokenRefreshRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * OAuthTokenRefreshRequest Class Doc Comment
@@ -289,7 +290,7 @@ class OAuthTokenRefreshRequest implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -302,7 +303,7 @@ class OAuthTokenRefreshRequest implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -316,7 +317,7 @@ class OAuthTokenRefreshRequest implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -333,7 +334,7 @@ class OAuthTokenRefreshRequest implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,7 +347,7 @@ class OAuthTokenRefreshRequest implements ModelInterface, ArrayAccess, JsonSeria
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/OAuthTokenResponse.php
+++ b/sdks/php/src/Model/OAuthTokenResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * OAuthTokenResponse Class Doc Comment
@@ -373,7 +374,7 @@ class OAuthTokenResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -386,7 +387,7 @@ class OAuthTokenResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -400,7 +401,7 @@ class OAuthTokenResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -417,7 +418,7 @@ class OAuthTokenResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -430,7 +431,7 @@ class OAuthTokenResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ReportCreateRequest.php
+++ b/sdks/php/src/Model/ReportCreateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ReportCreateRequest Class Doc Comment
@@ -363,7 +364,7 @@ class ReportCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -376,7 +377,7 @@ class ReportCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -390,7 +391,7 @@ class ReportCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -407,7 +408,7 @@ class ReportCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -420,7 +421,7 @@ class ReportCreateRequest implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ReportCreateResponse.php
+++ b/sdks/php/src/Model/ReportCreateResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ReportCreateResponse Class Doc Comment
@@ -283,7 +284,7 @@ class ReportCreateResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class ReportCreateResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class ReportCreateResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class ReportCreateResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class ReportCreateResponse implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/ReportResponse.php
+++ b/sdks/php/src/Model/ReportResponse.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * ReportResponse Class Doc Comment
@@ -370,7 +371,7 @@ class ReportResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -383,7 +384,7 @@ class ReportResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -397,7 +398,7 @@ class ReportResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -414,7 +415,7 @@ class ReportResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -427,7 +428,7 @@ class ReportResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestBulkCreateEmbeddedWithTemplateRequest.php
+++ b/sdks/php/src/Model/SignatureRequestBulkCreateEmbeddedWithTemplateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -644,7 +645,7 @@ class SignatureRequestBulkCreateEmbeddedWithTemplateRequest implements ModelInte
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -657,7 +658,7 @@ class SignatureRequestBulkCreateEmbeddedWithTemplateRequest implements ModelInte
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -671,7 +672,7 @@ class SignatureRequestBulkCreateEmbeddedWithTemplateRequest implements ModelInte
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -688,7 +689,7 @@ class SignatureRequestBulkCreateEmbeddedWithTemplateRequest implements ModelInte
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -701,7 +702,7 @@ class SignatureRequestBulkCreateEmbeddedWithTemplateRequest implements ModelInte
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestBulkSendWithTemplateRequest.php
+++ b/sdks/php/src/Model/SignatureRequestBulkSendWithTemplateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -641,7 +642,7 @@ class SignatureRequestBulkSendWithTemplateRequest implements ModelInterface, Arr
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -654,7 +655,7 @@ class SignatureRequestBulkSendWithTemplateRequest implements ModelInterface, Arr
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -668,7 +669,7 @@ class SignatureRequestBulkSendWithTemplateRequest implements ModelInterface, Arr
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -685,7 +686,7 @@ class SignatureRequestBulkSendWithTemplateRequest implements ModelInterface, Arr
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -698,7 +699,7 @@ class SignatureRequestBulkSendWithTemplateRequest implements ModelInterface, Arr
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestCreateEmbeddedRequest.php
+++ b/sdks/php/src/Model/SignatureRequestCreateEmbeddedRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -971,7 +972,7 @@ class SignatureRequestCreateEmbeddedRequest implements ModelInterface, ArrayAcce
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -984,7 +985,7 @@ class SignatureRequestCreateEmbeddedRequest implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -998,7 +999,7 @@ class SignatureRequestCreateEmbeddedRequest implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1015,7 +1016,7 @@ class SignatureRequestCreateEmbeddedRequest implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1028,7 +1029,7 @@ class SignatureRequestCreateEmbeddedRequest implements ModelInterface, ArrayAcce
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestCreateEmbeddedWithTemplateRequest.php
+++ b/sdks/php/src/Model/SignatureRequestCreateEmbeddedWithTemplateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -707,7 +708,7 @@ class SignatureRequestCreateEmbeddedWithTemplateRequest implements ModelInterfac
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -720,7 +721,7 @@ class SignatureRequestCreateEmbeddedWithTemplateRequest implements ModelInterfac
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -734,7 +735,7 @@ class SignatureRequestCreateEmbeddedWithTemplateRequest implements ModelInterfac
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -751,7 +752,7 @@ class SignatureRequestCreateEmbeddedWithTemplateRequest implements ModelInterfac
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -764,7 +765,7 @@ class SignatureRequestCreateEmbeddedWithTemplateRequest implements ModelInterfac
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestGetResponse.php
+++ b/sdks/php/src/Model/SignatureRequestGetResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestGetResponse Class Doc Comment
@@ -283,7 +284,7 @@ class SignatureRequestGetResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class SignatureRequestGetResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class SignatureRequestGetResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class SignatureRequestGetResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class SignatureRequestGetResponse implements ModelInterface, ArrayAccess, JsonSe
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestListResponse.php
+++ b/sdks/php/src/Model/SignatureRequestListResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestListResponse Class Doc Comment
@@ -313,7 +314,7 @@ class SignatureRequestListResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class SignatureRequestListResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class SignatureRequestListResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class SignatureRequestListResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class SignatureRequestListResponse implements ModelInterface, ArrayAccess, JsonS
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestRemindRequest.php
+++ b/sdks/php/src/Model/SignatureRequestRemindRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestRemindRequest Class Doc Comment
@@ -286,7 +287,7 @@ class SignatureRequestRemindRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -299,7 +300,7 @@ class SignatureRequestRemindRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -313,7 +314,7 @@ class SignatureRequestRemindRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -330,7 +331,7 @@ class SignatureRequestRemindRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -343,7 +344,7 @@ class SignatureRequestRemindRequest implements ModelInterface, ArrayAccess, Json
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponse.php
+++ b/sdks/php/src/Model/SignatureRequestResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponse Class Doc Comment
@@ -914,7 +915,7 @@ class SignatureRequestResponse implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -927,7 +928,7 @@ class SignatureRequestResponse implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -941,7 +942,7 @@ class SignatureRequestResponse implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -958,7 +959,7 @@ class SignatureRequestResponse implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -971,7 +972,7 @@ class SignatureRequestResponse implements ModelInterface, ArrayAccess, JsonSeria
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseAttachment.php
+++ b/sdks/php/src/Model/SignatureRequestResponseAttachment.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseAttachment Class Doc Comment
@@ -417,7 +418,7 @@ class SignatureRequestResponseAttachment implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -430,7 +431,7 @@ class SignatureRequestResponseAttachment implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -444,7 +445,7 @@ class SignatureRequestResponseAttachment implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -461,7 +462,7 @@ class SignatureRequestResponseAttachment implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -474,7 +475,7 @@ class SignatureRequestResponseAttachment implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseCustomFieldBase.php
+++ b/sdks/php/src/Model/SignatureRequestResponseCustomFieldBase.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseCustomFieldBase Class Doc Comment
@@ -382,7 +383,7 @@ abstract class SignatureRequestResponseCustomFieldBase implements ModelInterface
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -395,7 +396,7 @@ abstract class SignatureRequestResponseCustomFieldBase implements ModelInterface
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -409,7 +410,7 @@ abstract class SignatureRequestResponseCustomFieldBase implements ModelInterface
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -426,7 +427,7 @@ abstract class SignatureRequestResponseCustomFieldBase implements ModelInterface
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -439,7 +440,7 @@ abstract class SignatureRequestResponseCustomFieldBase implements ModelInterface
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseCustomFieldCheckbox.php
+++ b/sdks/php/src/Model/SignatureRequestResponseCustomFieldCheckbox.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseCustomFieldCheckbox Class Doc Comment
@@ -280,7 +281,7 @@ class SignatureRequestResponseCustomFieldCheckbox extends SignatureRequestRespon
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -293,7 +294,7 @@ class SignatureRequestResponseCustomFieldCheckbox extends SignatureRequestRespon
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -307,7 +308,7 @@ class SignatureRequestResponseCustomFieldCheckbox extends SignatureRequestRespon
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -324,7 +325,7 @@ class SignatureRequestResponseCustomFieldCheckbox extends SignatureRequestRespon
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -337,7 +338,7 @@ class SignatureRequestResponseCustomFieldCheckbox extends SignatureRequestRespon
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseCustomFieldText.php
+++ b/sdks/php/src/Model/SignatureRequestResponseCustomFieldText.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseCustomFieldText Class Doc Comment
@@ -280,7 +281,7 @@ class SignatureRequestResponseCustomFieldText extends SignatureRequestResponseCu
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -293,7 +294,7 @@ class SignatureRequestResponseCustomFieldText extends SignatureRequestResponseCu
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -307,7 +308,7 @@ class SignatureRequestResponseCustomFieldText extends SignatureRequestResponseCu
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -324,7 +325,7 @@ class SignatureRequestResponseCustomFieldText extends SignatureRequestResponseCu
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -337,7 +338,7 @@ class SignatureRequestResponseCustomFieldText extends SignatureRequestResponseCu
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataBase.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataBase.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataBase Class Doc Comment
@@ -396,7 +397,7 @@ abstract class SignatureRequestResponseDataBase implements ModelInterface, Array
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -409,7 +410,7 @@ abstract class SignatureRequestResponseDataBase implements ModelInterface, Array
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -423,7 +424,7 @@ abstract class SignatureRequestResponseDataBase implements ModelInterface, Array
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -440,7 +441,7 @@ abstract class SignatureRequestResponseDataBase implements ModelInterface, Array
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -453,7 +454,7 @@ abstract class SignatureRequestResponseDataBase implements ModelInterface, Array
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueCheckbox.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueCheckbox.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueCheckbox Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueCheckbox extends SignatureRequestResponse
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueCheckbox extends SignatureRequestResponse
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueCheckbox extends SignatureRequestResponse
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueCheckbox extends SignatureRequestResponse
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueCheckbox extends SignatureRequestResponse
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueCheckboxMerge.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueCheckboxMerge.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueCheckboxMerge Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueCheckboxMerge extends SignatureRequestRes
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueCheckboxMerge extends SignatureRequestRes
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueCheckboxMerge extends SignatureRequestRes
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueCheckboxMerge extends SignatureRequestRes
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueCheckboxMerge extends SignatureRequestRes
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueDateSigned.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueDateSigned.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueDateSigned Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueDateSigned extends SignatureRequestRespon
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueDateSigned extends SignatureRequestRespon
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueDateSigned extends SignatureRequestRespon
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueDateSigned extends SignatureRequestRespon
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueDateSigned extends SignatureRequestRespon
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueDropdown.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueDropdown.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueDropdown Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueDropdown extends SignatureRequestResponse
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueDropdown extends SignatureRequestResponse
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueDropdown extends SignatureRequestResponse
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueDropdown extends SignatureRequestResponse
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueDropdown extends SignatureRequestResponse
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueInitials.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueInitials.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueInitials Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueInitials extends SignatureRequestResponse
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueInitials extends SignatureRequestResponse
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueInitials extends SignatureRequestResponse
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueInitials extends SignatureRequestResponse
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueInitials extends SignatureRequestResponse
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueRadio.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueRadio.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueRadio Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueRadio extends SignatureRequestResponseDat
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueRadio extends SignatureRequestResponseDat
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueRadio extends SignatureRequestResponseDat
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueRadio extends SignatureRequestResponseDat
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueRadio extends SignatureRequestResponseDat
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueSignature.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueSignature.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueSignature Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueSignature extends SignatureRequestRespons
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueSignature extends SignatureRequestRespons
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueSignature extends SignatureRequestRespons
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueSignature extends SignatureRequestRespons
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueSignature extends SignatureRequestRespons
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueText.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueText.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueText Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueText extends SignatureRequestResponseData
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueText extends SignatureRequestResponseData
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueText extends SignatureRequestResponseData
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueText extends SignatureRequestResponseData
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueText extends SignatureRequestResponseData
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseDataValueTextMerge.php
+++ b/sdks/php/src/Model/SignatureRequestResponseDataValueTextMerge.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseDataValueTextMerge Class Doc Comment
@@ -275,7 +276,7 @@ class SignatureRequestResponseDataValueTextMerge extends SignatureRequestRespons
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -288,7 +289,7 @@ class SignatureRequestResponseDataValueTextMerge extends SignatureRequestRespons
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -302,7 +303,7 @@ class SignatureRequestResponseDataValueTextMerge extends SignatureRequestRespons
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -319,7 +320,7 @@ class SignatureRequestResponseDataValueTextMerge extends SignatureRequestRespons
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SignatureRequestResponseDataValueTextMerge extends SignatureRequestRespons
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestResponseSignatures.php
+++ b/sdks/php/src/Model/SignatureRequestResponseSignatures.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestResponseSignatures Class Doc Comment
@@ -794,7 +795,7 @@ class SignatureRequestResponseSignatures implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -807,7 +808,7 @@ class SignatureRequestResponseSignatures implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -821,7 +822,7 @@ class SignatureRequestResponseSignatures implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -838,7 +839,7 @@ class SignatureRequestResponseSignatures implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -851,7 +852,7 @@ class SignatureRequestResponseSignatures implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestSendRequest.php
+++ b/sdks/php/src/Model/SignatureRequestSendRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -998,7 +999,7 @@ class SignatureRequestSendRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1011,7 +1012,7 @@ class SignatureRequestSendRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -1025,7 +1026,7 @@ class SignatureRequestSendRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1042,7 +1043,7 @@ class SignatureRequestSendRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1055,7 +1056,7 @@ class SignatureRequestSendRequest implements ModelInterface, ArrayAccess, JsonSe
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestSendWithTemplateRequest.php
+++ b/sdks/php/src/Model/SignatureRequestSendWithTemplateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -734,7 +735,7 @@ class SignatureRequestSendWithTemplateRequest implements ModelInterface, ArrayAc
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -747,7 +748,7 @@ class SignatureRequestSendWithTemplateRequest implements ModelInterface, ArrayAc
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -761,7 +762,7 @@ class SignatureRequestSendWithTemplateRequest implements ModelInterface, ArrayAc
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -778,7 +779,7 @@ class SignatureRequestSendWithTemplateRequest implements ModelInterface, ArrayAc
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -791,7 +792,7 @@ class SignatureRequestSendWithTemplateRequest implements ModelInterface, ArrayAc
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SignatureRequestUpdateRequest.php
+++ b/sdks/php/src/Model/SignatureRequestUpdateRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SignatureRequestUpdateRequest Class Doc Comment
@@ -346,7 +347,7 @@ class SignatureRequestUpdateRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -359,7 +360,7 @@ class SignatureRequestUpdateRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -373,7 +374,7 @@ class SignatureRequestUpdateRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -390,7 +391,7 @@ class SignatureRequestUpdateRequest implements ModelInterface, ArrayAccess, Json
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -403,7 +404,7 @@ class SignatureRequestUpdateRequest implements ModelInterface, ArrayAccess, Json
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubAttachment.php
+++ b/sdks/php/src/Model/SubAttachment.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubAttachment Class Doc Comment
@@ -349,7 +350,7 @@ class SubAttachment implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -362,7 +363,7 @@ class SubAttachment implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -376,7 +377,7 @@ class SubAttachment implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -393,7 +394,7 @@ class SubAttachment implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -406,7 +407,7 @@ class SubAttachment implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubBulkSignerList.php
+++ b/sdks/php/src/Model/SubBulkSignerList.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubBulkSignerList Class Doc Comment
@@ -282,7 +283,7 @@ class SubBulkSignerList implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -295,7 +296,7 @@ class SubBulkSignerList implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -309,7 +310,7 @@ class SubBulkSignerList implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -326,7 +327,7 @@ class SubBulkSignerList implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -339,7 +340,7 @@ class SubBulkSignerList implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubBulkSignerListCustomField.php
+++ b/sdks/php/src/Model/SubBulkSignerListCustomField.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubBulkSignerListCustomField Class Doc Comment
@@ -289,7 +290,7 @@ class SubBulkSignerListCustomField implements ModelInterface, ArrayAccess, JsonS
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -302,7 +303,7 @@ class SubBulkSignerListCustomField implements ModelInterface, ArrayAccess, JsonS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -316,7 +317,7 @@ class SubBulkSignerListCustomField implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -333,7 +334,7 @@ class SubBulkSignerListCustomField implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,7 +347,7 @@ class SubBulkSignerListCustomField implements ModelInterface, ArrayAccess, JsonS
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubCC.php
+++ b/sdks/php/src/Model/SubCC.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubCC Class Doc Comment
@@ -289,7 +290,7 @@ class SubCC implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -302,7 +303,7 @@ class SubCC implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -316,7 +317,7 @@ class SubCC implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -333,7 +334,7 @@ class SubCC implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -346,7 +347,7 @@ class SubCC implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubCustomField.php
+++ b/sdks/php/src/Model/SubCustomField.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubCustomField Class Doc Comment
@@ -347,7 +348,7 @@ class SubCustomField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -360,7 +361,7 @@ class SubCustomField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +375,7 @@ class SubCustomField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -391,7 +392,7 @@ class SubCustomField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -404,7 +405,7 @@ class SubCustomField implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubEditorOptions.php
+++ b/sdks/php/src/Model/SubEditorOptions.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubEditorOptions Class Doc Comment
@@ -283,7 +284,7 @@ class SubEditorOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class SubEditorOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class SubEditorOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class SubEditorOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class SubEditorOptions implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFieldOptions.php
+++ b/sdks/php/src/Model/SubFieldOptions.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubFieldOptions Class Doc Comment
@@ -300,7 +301,7 @@ class SubFieldOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -313,7 +314,7 @@ class SubFieldOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -327,7 +328,7 @@ class SubFieldOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -344,7 +345,7 @@ class SubFieldOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -357,7 +358,7 @@ class SubFieldOptions implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldGroup.php
+++ b/sdks/php/src/Model/SubFormFieldGroup.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldGroup Class Doc Comment
@@ -322,7 +323,7 @@ class SubFormFieldGroup implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,7 +336,7 @@ class SubFormFieldGroup implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -349,7 +350,7 @@ class SubFormFieldGroup implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,7 +367,7 @@ class SubFormFieldGroup implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,7 +380,7 @@ class SubFormFieldGroup implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldRule.php
+++ b/sdks/php/src/Model/SubFormFieldRule.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldRule Class Doc Comment
@@ -376,7 +377,7 @@ class SubFormFieldRule implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -389,7 +390,7 @@ class SubFormFieldRule implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -403,7 +404,7 @@ class SubFormFieldRule implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -420,7 +421,7 @@ class SubFormFieldRule implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -433,7 +434,7 @@ class SubFormFieldRule implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldRuleAction.php
+++ b/sdks/php/src/Model/SubFormFieldRuleAction.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldRuleAction Class Doc Comment
@@ -384,7 +385,7 @@ class SubFormFieldRuleAction implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -397,7 +398,7 @@ class SubFormFieldRuleAction implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -411,7 +412,7 @@ class SubFormFieldRuleAction implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -428,7 +429,7 @@ class SubFormFieldRuleAction implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -441,7 +442,7 @@ class SubFormFieldRuleAction implements ModelInterface, ArrayAccess, JsonSeriali
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldRuleTrigger.php
+++ b/sdks/php/src/Model/SubFormFieldRuleTrigger.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldRuleTrigger Class Doc Comment
@@ -390,7 +391,7 @@ class SubFormFieldRuleTrigger implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -403,7 +404,7 @@ class SubFormFieldRuleTrigger implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -417,7 +418,7 @@ class SubFormFieldRuleTrigger implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -434,7 +435,7 @@ class SubFormFieldRuleTrigger implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -447,7 +448,7 @@ class SubFormFieldRuleTrigger implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentBase.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentBase.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentBase Class Doc Comment
@@ -607,7 +608,7 @@ abstract class SubFormFieldsPerDocumentBase implements ModelInterface, ArrayAcce
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -620,7 +621,7 @@ abstract class SubFormFieldsPerDocumentBase implements ModelInterface, ArrayAcce
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -634,7 +635,7 @@ abstract class SubFormFieldsPerDocumentBase implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -651,7 +652,7 @@ abstract class SubFormFieldsPerDocumentBase implements ModelInterface, ArrayAcce
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -664,7 +665,7 @@ abstract class SubFormFieldsPerDocumentBase implements ModelInterface, ArrayAcce
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentCheckbox.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentCheckbox.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentCheckbox Class Doc Comment
@@ -313,7 +314,7 @@ class SubFormFieldsPerDocumentCheckbox extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class SubFormFieldsPerDocumentCheckbox extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class SubFormFieldsPerDocumentCheckbox extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class SubFormFieldsPerDocumentCheckbox extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class SubFormFieldsPerDocumentCheckbox extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentCheckboxMerge.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentCheckboxMerge.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentCheckboxMerge Class Doc Comment
@@ -250,7 +251,7 @@ class SubFormFieldsPerDocumentCheckboxMerge extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class SubFormFieldsPerDocumentCheckboxMerge extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class SubFormFieldsPerDocumentCheckboxMerge extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class SubFormFieldsPerDocumentCheckboxMerge extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class SubFormFieldsPerDocumentCheckboxMerge extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentDateSigned.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentDateSigned.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentDateSigned Class Doc Comment
@@ -250,7 +251,7 @@ class SubFormFieldsPerDocumentDateSigned extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class SubFormFieldsPerDocumentDateSigned extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class SubFormFieldsPerDocumentDateSigned extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class SubFormFieldsPerDocumentDateSigned extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class SubFormFieldsPerDocumentDateSigned extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentDropdown.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentDropdown.php
@@ -30,6 +30,7 @@ namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentDropdown Class Doc Comment
@@ -320,7 +321,7 @@ class SubFormFieldsPerDocumentDropdown extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -333,7 +334,7 @@ class SubFormFieldsPerDocumentDropdown extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -347,7 +348,7 @@ class SubFormFieldsPerDocumentDropdown extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -364,7 +365,7 @@ class SubFormFieldsPerDocumentDropdown extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -377,7 +378,7 @@ class SubFormFieldsPerDocumentDropdown extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentHyperlink.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentHyperlink.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentHyperlink Class Doc Comment
@@ -316,7 +317,7 @@ class SubFormFieldsPerDocumentHyperlink extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -329,7 +330,7 @@ class SubFormFieldsPerDocumentHyperlink extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -343,7 +344,7 @@ class SubFormFieldsPerDocumentHyperlink extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -360,7 +361,7 @@ class SubFormFieldsPerDocumentHyperlink extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -373,7 +374,7 @@ class SubFormFieldsPerDocumentHyperlink extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentInitials.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentInitials.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentInitials Class Doc Comment
@@ -250,7 +251,7 @@ class SubFormFieldsPerDocumentInitials extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class SubFormFieldsPerDocumentInitials extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class SubFormFieldsPerDocumentInitials extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class SubFormFieldsPerDocumentInitials extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class SubFormFieldsPerDocumentInitials extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentRadio.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentRadio.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentRadio Class Doc Comment
@@ -316,7 +317,7 @@ class SubFormFieldsPerDocumentRadio extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -329,7 +330,7 @@ class SubFormFieldsPerDocumentRadio extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -343,7 +344,7 @@ class SubFormFieldsPerDocumentRadio extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -360,7 +361,7 @@ class SubFormFieldsPerDocumentRadio extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -373,7 +374,7 @@ class SubFormFieldsPerDocumentRadio extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentSignature.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentSignature.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentSignature Class Doc Comment
@@ -250,7 +251,7 @@ class SubFormFieldsPerDocumentSignature extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class SubFormFieldsPerDocumentSignature extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class SubFormFieldsPerDocumentSignature extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class SubFormFieldsPerDocumentSignature extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class SubFormFieldsPerDocumentSignature extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentText.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentText.php
@@ -30,6 +30,7 @@ namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentText Class Doc Comment
@@ -511,7 +512,7 @@ class SubFormFieldsPerDocumentText extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -524,7 +525,7 @@ class SubFormFieldsPerDocumentText extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -538,7 +539,7 @@ class SubFormFieldsPerDocumentText extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -555,7 +556,7 @@ class SubFormFieldsPerDocumentText extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -568,7 +569,7 @@ class SubFormFieldsPerDocumentText extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubFormFieldsPerDocumentTextMerge.php
+++ b/sdks/php/src/Model/SubFormFieldsPerDocumentTextMerge.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * SubFormFieldsPerDocumentTextMerge Class Doc Comment
@@ -250,7 +251,7 @@ class SubFormFieldsPerDocumentTextMerge extends SubFormFieldsPerDocumentBase
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class SubFormFieldsPerDocumentTextMerge extends SubFormFieldsPerDocumentBase
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class SubFormFieldsPerDocumentTextMerge extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class SubFormFieldsPerDocumentTextMerge extends SubFormFieldsPerDocumentBase
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class SubFormFieldsPerDocumentTextMerge extends SubFormFieldsPerDocumentBase
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubMergeField.php
+++ b/sdks/php/src/Model/SubMergeField.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubMergeField Class Doc Comment
@@ -324,7 +325,7 @@ class SubMergeField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -337,7 +338,7 @@ class SubMergeField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -351,7 +352,7 @@ class SubMergeField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -368,7 +369,7 @@ class SubMergeField implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -381,7 +382,7 @@ class SubMergeField implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubOAuth.php
+++ b/sdks/php/src/Model/SubOAuth.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubOAuth Class Doc Comment
@@ -321,7 +322,7 @@ class SubOAuth implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -334,7 +335,7 @@ class SubOAuth implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -348,7 +349,7 @@ class SubOAuth implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -365,7 +366,7 @@ class SubOAuth implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -378,7 +379,7 @@ class SubOAuth implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubOptions.php
+++ b/sdks/php/src/Model/SubOptions.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubOptions Class Doc Comment
@@ -253,7 +254,7 @@ class SubOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -266,7 +267,7 @@ class SubOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -280,7 +281,7 @@ class SubOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -297,7 +298,7 @@ class SubOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -310,7 +311,7 @@ class SubOptions implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubSignatureRequestGroupedSigners.php
+++ b/sdks/php/src/Model/SubSignatureRequestGroupedSigners.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubSignatureRequestGroupedSigners Class Doc Comment
@@ -319,7 +320,7 @@ class SubSignatureRequestGroupedSigners implements ModelInterface, ArrayAccess, 
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SubSignatureRequestGroupedSigners implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -346,7 +347,7 @@ class SubSignatureRequestGroupedSigners implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -363,7 +364,7 @@ class SubSignatureRequestGroupedSigners implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,7 +377,7 @@ class SubSignatureRequestGroupedSigners implements ModelInterface, ArrayAccess, 
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubSignatureRequestSigner.php
+++ b/sdks/php/src/Model/SubSignatureRequestSigner.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubSignatureRequestSigner Class Doc Comment
@@ -459,7 +460,7 @@ class SubSignatureRequestSigner implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -472,7 +473,7 @@ class SubSignatureRequestSigner implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -486,7 +487,7 @@ class SubSignatureRequestSigner implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -503,7 +504,7 @@ class SubSignatureRequestSigner implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -516,7 +517,7 @@ class SubSignatureRequestSigner implements ModelInterface, ArrayAccess, JsonSeri
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubSignatureRequestTemplateSigner.php
+++ b/sdks/php/src/Model/SubSignatureRequestTemplateSigner.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubSignatureRequestTemplateSigner Class Doc Comment
@@ -462,7 +463,7 @@ class SubSignatureRequestTemplateSigner implements ModelInterface, ArrayAccess, 
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -475,7 +476,7 @@ class SubSignatureRequestTemplateSigner implements ModelInterface, ArrayAccess, 
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -489,7 +490,7 @@ class SubSignatureRequestTemplateSigner implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -506,7 +507,7 @@ class SubSignatureRequestTemplateSigner implements ModelInterface, ArrayAccess, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -519,7 +520,7 @@ class SubSignatureRequestTemplateSigner implements ModelInterface, ArrayAccess, 
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubSigningOptions.php
+++ b/sdks/php/src/Model/SubSigningOptions.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubSigningOptions Class Doc Comment
@@ -416,7 +417,7 @@ class SubSigningOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -429,7 +430,7 @@ class SubSigningOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -443,7 +444,7 @@ class SubSigningOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -460,7 +461,7 @@ class SubSigningOptions implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -473,7 +474,7 @@ class SubSigningOptions implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubTeamResponse.php
+++ b/sdks/php/src/Model/SubTeamResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubTeamResponse Class Doc Comment
@@ -283,7 +284,7 @@ class SubTeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class SubTeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class SubTeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class SubTeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class SubTeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubTemplateRole.php
+++ b/sdks/php/src/Model/SubTemplateRole.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubTemplateRole Class Doc Comment
@@ -282,7 +283,7 @@ class SubTemplateRole implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -295,7 +296,7 @@ class SubTemplateRole implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -309,7 +310,7 @@ class SubTemplateRole implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -326,7 +327,7 @@ class SubTemplateRole implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -339,7 +340,7 @@ class SubTemplateRole implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubUnclaimedDraftSigner.php
+++ b/sdks/php/src/Model/SubUnclaimedDraftSigner.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubUnclaimedDraftSigner Class Doc Comment
@@ -319,7 +320,7 @@ class SubUnclaimedDraftSigner implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -332,7 +333,7 @@ class SubUnclaimedDraftSigner implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -346,7 +347,7 @@ class SubUnclaimedDraftSigner implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -363,7 +364,7 @@ class SubUnclaimedDraftSigner implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -376,7 +377,7 @@ class SubUnclaimedDraftSigner implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubUnclaimedDraftTemplateSigner.php
+++ b/sdks/php/src/Model/SubUnclaimedDraftTemplateSigner.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubUnclaimedDraftTemplateSigner Class Doc Comment
@@ -322,7 +323,7 @@ class SubUnclaimedDraftTemplateSigner implements ModelInterface, ArrayAccess, Js
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -335,7 +336,7 @@ class SubUnclaimedDraftTemplateSigner implements ModelInterface, ArrayAccess, Js
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -349,7 +350,7 @@ class SubUnclaimedDraftTemplateSigner implements ModelInterface, ArrayAccess, Js
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -366,7 +367,7 @@ class SubUnclaimedDraftTemplateSigner implements ModelInterface, ArrayAccess, Js
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -379,7 +380,7 @@ class SubUnclaimedDraftTemplateSigner implements ModelInterface, ArrayAccess, Js
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/SubWhiteLabelingOptions.php
+++ b/sdks/php/src/Model/SubWhiteLabelingOptions.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * SubWhiteLabelingOptions Class Doc Comment
@@ -709,7 +710,7 @@ class SubWhiteLabelingOptions implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -722,7 +723,7 @@ class SubWhiteLabelingOptions implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -736,7 +737,7 @@ class SubWhiteLabelingOptions implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -753,7 +754,7 @@ class SubWhiteLabelingOptions implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -766,7 +767,7 @@ class SubWhiteLabelingOptions implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamAddMemberRequest.php
+++ b/sdks/php/src/Model/TeamAddMemberRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamAddMemberRequest Class Doc Comment
@@ -352,7 +353,7 @@ class TeamAddMemberRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -365,7 +366,7 @@ class TeamAddMemberRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -379,7 +380,7 @@ class TeamAddMemberRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -396,7 +397,7 @@ class TeamAddMemberRequest implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -409,7 +410,7 @@ class TeamAddMemberRequest implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamCreateRequest.php
+++ b/sdks/php/src/Model/TeamCreateRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamCreateRequest Class Doc Comment
@@ -252,7 +253,7 @@ class TeamCreateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -265,7 +266,7 @@ class TeamCreateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -279,7 +280,7 @@ class TeamCreateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -296,7 +297,7 @@ class TeamCreateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -309,7 +310,7 @@ class TeamCreateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamGetInfoResponse.php
+++ b/sdks/php/src/Model/TeamGetInfoResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamGetInfoResponse Class Doc Comment
@@ -283,7 +284,7 @@ class TeamGetInfoResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TeamGetInfoResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TeamGetInfoResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TeamGetInfoResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TeamGetInfoResponse implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamGetResponse.php
+++ b/sdks/php/src/Model/TeamGetResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamGetResponse Class Doc Comment
@@ -283,7 +284,7 @@ class TeamGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TeamGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TeamGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TeamGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TeamGetResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamInfoResponse.php
+++ b/sdks/php/src/Model/TeamInfoResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamInfoResponse Class Doc Comment
@@ -373,7 +374,7 @@ class TeamInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -386,7 +387,7 @@ class TeamInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -400,7 +401,7 @@ class TeamInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -417,7 +418,7 @@ class TeamInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -430,7 +431,7 @@ class TeamInfoResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamInviteResponse.php
+++ b/sdks/php/src/Model/TeamInviteResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamInviteResponse Class Doc Comment
@@ -403,7 +404,7 @@ class TeamInviteResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -416,7 +417,7 @@ class TeamInviteResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -430,7 +431,7 @@ class TeamInviteResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -447,7 +448,7 @@ class TeamInviteResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -460,7 +461,7 @@ class TeamInviteResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamInvitesResponse.php
+++ b/sdks/php/src/Model/TeamInvitesResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamInvitesResponse Class Doc Comment
@@ -283,7 +284,7 @@ class TeamInvitesResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TeamInvitesResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TeamInvitesResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TeamInvitesResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TeamInvitesResponse implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamMemberResponse.php
+++ b/sdks/php/src/Model/TeamMemberResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamMemberResponse Class Doc Comment
@@ -313,7 +314,7 @@ class TeamMemberResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class TeamMemberResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class TeamMemberResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class TeamMemberResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class TeamMemberResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamMembersResponse.php
+++ b/sdks/php/src/Model/TeamMembersResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamMembersResponse Class Doc Comment
@@ -313,7 +314,7 @@ class TeamMembersResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class TeamMembersResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class TeamMembersResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class TeamMembersResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class TeamMembersResponse implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamParentResponse.php
+++ b/sdks/php/src/Model/TeamParentResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamParentResponse Class Doc Comment
@@ -284,7 +285,7 @@ class TeamParentResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class TeamParentResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class TeamParentResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class TeamParentResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class TeamParentResponse implements ModelInterface, ArrayAccess, JsonSerializabl
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamRemoveMemberRequest.php
+++ b/sdks/php/src/Model/TeamRemoveMemberRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamRemoveMemberRequest Class Doc Comment
@@ -412,7 +413,7 @@ class TeamRemoveMemberRequest implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -425,7 +426,7 @@ class TeamRemoveMemberRequest implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -439,7 +440,7 @@ class TeamRemoveMemberRequest implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -456,7 +457,7 @@ class TeamRemoveMemberRequest implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -469,7 +470,7 @@ class TeamRemoveMemberRequest implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamResponse.php
+++ b/sdks/php/src/Model/TeamResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamResponse Class Doc Comment
@@ -344,7 +345,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -357,7 +358,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -371,7 +372,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -388,7 +389,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -401,7 +402,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamSubTeamsResponse.php
+++ b/sdks/php/src/Model/TeamSubTeamsResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamSubTeamsResponse Class Doc Comment
@@ -313,7 +314,7 @@ class TeamSubTeamsResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class TeamSubTeamsResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class TeamSubTeamsResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class TeamSubTeamsResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class TeamSubTeamsResponse implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TeamUpdateRequest.php
+++ b/sdks/php/src/Model/TeamUpdateRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TeamUpdateRequest Class Doc Comment
@@ -252,7 +253,7 @@ class TeamUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -265,7 +266,7 @@ class TeamUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -279,7 +280,7 @@ class TeamUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -296,7 +297,7 @@ class TeamUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -309,7 +310,7 @@ class TeamUpdateRequest implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateAddUserRequest.php
+++ b/sdks/php/src/Model/TemplateAddUserRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateAddUserRequest Class Doc Comment
@@ -312,7 +313,7 @@ class TemplateAddUserRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -325,7 +326,7 @@ class TemplateAddUserRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -339,7 +340,7 @@ class TemplateAddUserRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -356,7 +357,7 @@ class TemplateAddUserRequest implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -369,7 +370,7 @@ class TemplateAddUserRequest implements ModelInterface, ArrayAccess, JsonSeriali
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateCreateEmbeddedDraftRequest.php
+++ b/sdks/php/src/Model/TemplateCreateEmbeddedDraftRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -993,7 +994,7 @@ class TemplateCreateEmbeddedDraftRequest implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1006,7 +1007,7 @@ class TemplateCreateEmbeddedDraftRequest implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -1020,7 +1021,7 @@ class TemplateCreateEmbeddedDraftRequest implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1037,7 +1038,7 @@ class TemplateCreateEmbeddedDraftRequest implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1050,7 +1051,7 @@ class TemplateCreateEmbeddedDraftRequest implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateCreateEmbeddedDraftResponse.php
+++ b/sdks/php/src/Model/TemplateCreateEmbeddedDraftResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateCreateEmbeddedDraftResponse Class Doc Comment
@@ -283,7 +284,7 @@ class TemplateCreateEmbeddedDraftResponse implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TemplateCreateEmbeddedDraftResponse implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TemplateCreateEmbeddedDraftResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TemplateCreateEmbeddedDraftResponse implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TemplateCreateEmbeddedDraftResponse implements ModelInterface, ArrayAccess
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateCreateEmbeddedDraftResponseTemplate.php
+++ b/sdks/php/src/Model/TemplateCreateEmbeddedDraftResponseTemplate.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateCreateEmbeddedDraftResponseTemplate Class Doc Comment
@@ -344,7 +345,7 @@ class TemplateCreateEmbeddedDraftResponseTemplate implements ModelInterface, Arr
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -357,7 +358,7 @@ class TemplateCreateEmbeddedDraftResponseTemplate implements ModelInterface, Arr
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -371,7 +372,7 @@ class TemplateCreateEmbeddedDraftResponseTemplate implements ModelInterface, Arr
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -388,7 +389,7 @@ class TemplateCreateEmbeddedDraftResponseTemplate implements ModelInterface, Arr
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -401,7 +402,7 @@ class TemplateCreateEmbeddedDraftResponseTemplate implements ModelInterface, Arr
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateEditResponse.php
+++ b/sdks/php/src/Model/TemplateEditResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateEditResponse Class Doc Comment
@@ -252,7 +253,7 @@ class TemplateEditResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -265,7 +266,7 @@ class TemplateEditResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -279,7 +280,7 @@ class TemplateEditResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -296,7 +297,7 @@ class TemplateEditResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -309,7 +310,7 @@ class TemplateEditResponse implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateGetResponse.php
+++ b/sdks/php/src/Model/TemplateGetResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateGetResponse Class Doc Comment
@@ -283,7 +284,7 @@ class TemplateGetResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TemplateGetResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TemplateGetResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TemplateGetResponse implements ModelInterface, ArrayAccess, JsonSerializab
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TemplateGetResponse implements ModelInterface, ArrayAccess, JsonSerializab
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateListResponse.php
+++ b/sdks/php/src/Model/TemplateListResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateListResponse Class Doc Comment
@@ -313,7 +314,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -326,7 +327,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -340,7 +341,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -357,7 +358,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, JsonSerializa
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -370,7 +371,7 @@ class TemplateListResponse implements ModelInterface, ArrayAccess, JsonSerializa
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateRemoveUserRequest.php
+++ b/sdks/php/src/Model/TemplateRemoveUserRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateRemoveUserRequest Class Doc Comment
@@ -282,7 +283,7 @@ class TemplateRemoveUserRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -295,7 +296,7 @@ class TemplateRemoveUserRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -309,7 +310,7 @@ class TemplateRemoveUserRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -326,7 +327,7 @@ class TemplateRemoveUserRequest implements ModelInterface, ArrayAccess, JsonSeri
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -339,7 +340,7 @@ class TemplateRemoveUserRequest implements ModelInterface, ArrayAccess, JsonSeri
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponse.php
+++ b/sdks/php/src/Model/TemplateResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponse Class Doc Comment
@@ -678,7 +679,7 @@ class TemplateResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -691,7 +692,7 @@ class TemplateResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -705,7 +706,7 @@ class TemplateResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -722,7 +723,7 @@ class TemplateResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -735,7 +736,7 @@ class TemplateResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseAccount.php
+++ b/sdks/php/src/Model/TemplateResponseAccount.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseAccount Class Doc Comment
@@ -403,7 +404,7 @@ class TemplateResponseAccount implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -416,7 +417,7 @@ class TemplateResponseAccount implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -430,7 +431,7 @@ class TemplateResponseAccount implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -447,7 +448,7 @@ class TemplateResponseAccount implements ModelInterface, ArrayAccess, JsonSerial
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -460,7 +461,7 @@ class TemplateResponseAccount implements ModelInterface, ArrayAccess, JsonSerial
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseAccountQuota.php
+++ b/sdks/php/src/Model/TemplateResponseAccountQuota.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseAccountQuota Class Doc Comment
@@ -344,7 +345,7 @@ class TemplateResponseAccountQuota implements ModelInterface, ArrayAccess, JsonS
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -357,7 +358,7 @@ class TemplateResponseAccountQuota implements ModelInterface, ArrayAccess, JsonS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -371,7 +372,7 @@ class TemplateResponseAccountQuota implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -388,7 +389,7 @@ class TemplateResponseAccountQuota implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -401,7 +402,7 @@ class TemplateResponseAccountQuota implements ModelInterface, ArrayAccess, JsonS
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseCCRole.php
+++ b/sdks/php/src/Model/TemplateResponseCCRole.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseCCRole Class Doc Comment
@@ -253,7 +254,7 @@ class TemplateResponseCCRole implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -266,7 +267,7 @@ class TemplateResponseCCRole implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -280,7 +281,7 @@ class TemplateResponseCCRole implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -297,7 +298,7 @@ class TemplateResponseCCRole implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -310,7 +311,7 @@ class TemplateResponseCCRole implements ModelInterface, ArrayAccess, JsonSeriali
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocument.php
+++ b/sdks/php/src/Model/TemplateResponseDocument.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocument Class Doc Comment
@@ -403,7 +404,7 @@ class TemplateResponseDocument implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -416,7 +417,7 @@ class TemplateResponseDocument implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -430,7 +431,7 @@ class TemplateResponseDocument implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -447,7 +448,7 @@ class TemplateResponseDocument implements ModelInterface, ArrayAccess, JsonSeria
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -460,7 +461,7 @@ class TemplateResponseDocument implements ModelInterface, ArrayAccess, JsonSeria
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentCustomFieldBase.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentCustomFieldBase.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentCustomFieldBase Class Doc Comment
@@ -529,7 +530,7 @@ abstract class TemplateResponseDocumentCustomFieldBase implements ModelInterface
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -542,7 +543,7 @@ abstract class TemplateResponseDocumentCustomFieldBase implements ModelInterface
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -556,7 +557,7 @@ abstract class TemplateResponseDocumentCustomFieldBase implements ModelInterface
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -573,7 +574,7 @@ abstract class TemplateResponseDocumentCustomFieldBase implements ModelInterface
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -586,7 +587,7 @@ abstract class TemplateResponseDocumentCustomFieldBase implements ModelInterface
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentCustomFieldCheckbox.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentCustomFieldCheckbox.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentCustomFieldCheckbox Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentCustomFieldCheckbox extends TemplateResponseDocume
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentCustomFieldCheckbox extends TemplateResponseDocume
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentCustomFieldCheckbox extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentCustomFieldCheckbox extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentCustomFieldCheckbox extends TemplateResponseDocume
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentCustomFieldText.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentCustomFieldText.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentCustomFieldText Class Doc Comment
@@ -370,7 +371,7 @@ class TemplateResponseDocumentCustomFieldText extends TemplateResponseDocumentCu
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -383,7 +384,7 @@ class TemplateResponseDocumentCustomFieldText extends TemplateResponseDocumentCu
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -397,7 +398,7 @@ class TemplateResponseDocumentCustomFieldText extends TemplateResponseDocumentCu
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -414,7 +415,7 @@ class TemplateResponseDocumentCustomFieldText extends TemplateResponseDocumentCu
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -427,7 +428,7 @@ class TemplateResponseDocumentCustomFieldText extends TemplateResponseDocumentCu
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFieldGroup.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFieldGroup.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFieldGroup Class Doc Comment
@@ -283,7 +284,7 @@ class TemplateResponseDocumentFieldGroup implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TemplateResponseDocumentFieldGroup implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TemplateResponseDocumentFieldGroup implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TemplateResponseDocumentFieldGroup implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TemplateResponseDocumentFieldGroup implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFieldGroupRule.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFieldGroupRule.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFieldGroupRule Class Doc Comment
@@ -284,7 +285,7 @@ class TemplateResponseDocumentFieldGroupRule implements ModelInterface, ArrayAcc
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class TemplateResponseDocumentFieldGroupRule implements ModelInterface, ArrayAcc
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class TemplateResponseDocumentFieldGroupRule implements ModelInterface, ArrayAcc
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class TemplateResponseDocumentFieldGroupRule implements ModelInterface, ArrayAcc
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class TemplateResponseDocumentFieldGroupRule implements ModelInterface, ArrayAcc
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldBase.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldBase.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldBase Class Doc Comment
@@ -547,7 +548,7 @@ abstract class TemplateResponseDocumentFormFieldBase implements ModelInterface, 
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -560,7 +561,7 @@ abstract class TemplateResponseDocumentFormFieldBase implements ModelInterface, 
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -574,7 +575,7 @@ abstract class TemplateResponseDocumentFormFieldBase implements ModelInterface, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -591,7 +592,7 @@ abstract class TemplateResponseDocumentFormFieldBase implements ModelInterface, 
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -604,7 +605,7 @@ abstract class TemplateResponseDocumentFormFieldBase implements ModelInterface, 
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldCheckbox.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldCheckbox.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldCheckbox Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentFormFieldCheckbox extends TemplateResponseDocument
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentFormFieldCheckbox extends TemplateResponseDocument
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentFormFieldCheckbox extends TemplateResponseDocument
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentFormFieldCheckbox extends TemplateResponseDocument
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentFormFieldCheckbox extends TemplateResponseDocument
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldDateSigned.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldDateSigned.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldDateSigned Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentFormFieldDateSigned extends TemplateResponseDocume
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentFormFieldDateSigned extends TemplateResponseDocume
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentFormFieldDateSigned extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentFormFieldDateSigned extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentFormFieldDateSigned extends TemplateResponseDocume
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldDropdown.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldDropdown.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldDropdown Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentFormFieldDropdown extends TemplateResponseDocument
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentFormFieldDropdown extends TemplateResponseDocument
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentFormFieldDropdown extends TemplateResponseDocument
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentFormFieldDropdown extends TemplateResponseDocument
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentFormFieldDropdown extends TemplateResponseDocument
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldHyperlink.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldHyperlink.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldHyperlink Class Doc Comment
@@ -370,7 +371,7 @@ class TemplateResponseDocumentFormFieldHyperlink extends TemplateResponseDocumen
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -383,7 +384,7 @@ class TemplateResponseDocumentFormFieldHyperlink extends TemplateResponseDocumen
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -397,7 +398,7 @@ class TemplateResponseDocumentFormFieldHyperlink extends TemplateResponseDocumen
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -414,7 +415,7 @@ class TemplateResponseDocumentFormFieldHyperlink extends TemplateResponseDocumen
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -427,7 +428,7 @@ class TemplateResponseDocumentFormFieldHyperlink extends TemplateResponseDocumen
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldInitials.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldInitials.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldInitials Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentFormFieldInitials extends TemplateResponseDocument
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentFormFieldInitials extends TemplateResponseDocument
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentFormFieldInitials extends TemplateResponseDocument
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentFormFieldInitials extends TemplateResponseDocument
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentFormFieldInitials extends TemplateResponseDocument
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldRadio.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldRadio.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldRadio Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentFormFieldRadio extends TemplateResponseDocumentFor
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentFormFieldRadio extends TemplateResponseDocumentFor
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentFormFieldRadio extends TemplateResponseDocumentFor
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentFormFieldRadio extends TemplateResponseDocumentFor
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentFormFieldRadio extends TemplateResponseDocumentFor
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldSignature.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldSignature.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldSignature Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentFormFieldSignature extends TemplateResponseDocumen
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentFormFieldSignature extends TemplateResponseDocumen
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentFormFieldSignature extends TemplateResponseDocumen
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentFormFieldSignature extends TemplateResponseDocumen
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentFormFieldSignature extends TemplateResponseDocumen
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentFormFieldText.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentFormFieldText.php
@@ -30,6 +30,7 @@ namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentFormFieldText Class Doc Comment
@@ -451,7 +452,7 @@ class TemplateResponseDocumentFormFieldText extends TemplateResponseDocumentForm
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -464,7 +465,7 @@ class TemplateResponseDocumentFormFieldText extends TemplateResponseDocumentForm
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -478,7 +479,7 @@ class TemplateResponseDocumentFormFieldText extends TemplateResponseDocumentForm
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -495,7 +496,7 @@ class TemplateResponseDocumentFormFieldText extends TemplateResponseDocumentForm
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -508,7 +509,7 @@ class TemplateResponseDocumentFormFieldText extends TemplateResponseDocumentForm
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldBase.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldBase.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldBase Class Doc Comment
@@ -547,7 +548,7 @@ abstract class TemplateResponseDocumentStaticFieldBase implements ModelInterface
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -560,7 +561,7 @@ abstract class TemplateResponseDocumentStaticFieldBase implements ModelInterface
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -574,7 +575,7 @@ abstract class TemplateResponseDocumentStaticFieldBase implements ModelInterface
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -591,7 +592,7 @@ abstract class TemplateResponseDocumentStaticFieldBase implements ModelInterface
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -604,7 +605,7 @@ abstract class TemplateResponseDocumentStaticFieldBase implements ModelInterface
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldCheckbox.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldCheckbox.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldCheckbox Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldCheckbox extends TemplateResponseDocume
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldCheckbox extends TemplateResponseDocume
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldCheckbox extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldCheckbox extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldCheckbox extends TemplateResponseDocume
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldDateSigned.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldDateSigned.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldDateSigned Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldDateSigned extends TemplateResponseDocu
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldDateSigned extends TemplateResponseDocu
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldDateSigned extends TemplateResponseDocu
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldDateSigned extends TemplateResponseDocu
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldDateSigned extends TemplateResponseDocu
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldDropdown.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldDropdown.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldDropdown Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldDropdown extends TemplateResponseDocume
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldDropdown extends TemplateResponseDocume
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldDropdown extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldDropdown extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldDropdown extends TemplateResponseDocume
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldHyperlink.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldHyperlink.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldHyperlink Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldHyperlink extends TemplateResponseDocum
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldHyperlink extends TemplateResponseDocum
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldHyperlink extends TemplateResponseDocum
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldHyperlink extends TemplateResponseDocum
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldHyperlink extends TemplateResponseDocum
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldInitials.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldInitials.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldInitials Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldInitials extends TemplateResponseDocume
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldInitials extends TemplateResponseDocume
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldInitials extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldInitials extends TemplateResponseDocume
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldInitials extends TemplateResponseDocume
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldRadio.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldRadio.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldRadio Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldRadio extends TemplateResponseDocumentS
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldRadio extends TemplateResponseDocumentS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldRadio extends TemplateResponseDocumentS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldRadio extends TemplateResponseDocumentS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldRadio extends TemplateResponseDocumentS
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldSignature.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldSignature.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldSignature Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldSignature extends TemplateResponseDocum
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldSignature extends TemplateResponseDocum
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldSignature extends TemplateResponseDocum
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldSignature extends TemplateResponseDocum
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldSignature extends TemplateResponseDocum
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseDocumentStaticFieldText.php
+++ b/sdks/php/src/Model/TemplateResponseDocumentStaticFieldText.php
@@ -29,6 +29,7 @@
 namespace Dropbox\Sign\Model;
 
 use Dropbox\Sign\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseDocumentStaticFieldText Class Doc Comment
@@ -250,7 +251,7 @@ class TemplateResponseDocumentStaticFieldText extends TemplateResponseDocumentSt
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -263,7 +264,7 @@ class TemplateResponseDocumentStaticFieldText extends TemplateResponseDocumentSt
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -277,7 +278,7 @@ class TemplateResponseDocumentStaticFieldText extends TemplateResponseDocumentSt
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -294,7 +295,7 @@ class TemplateResponseDocumentStaticFieldText extends TemplateResponseDocumentSt
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -307,7 +308,7 @@ class TemplateResponseDocumentStaticFieldText extends TemplateResponseDocumentSt
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseFieldAvgTextLength.php
+++ b/sdks/php/src/Model/TemplateResponseFieldAvgTextLength.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseFieldAvgTextLength Class Doc Comment
@@ -284,7 +285,7 @@ class TemplateResponseFieldAvgTextLength implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class TemplateResponseFieldAvgTextLength implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class TemplateResponseFieldAvgTextLength implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class TemplateResponseFieldAvgTextLength implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class TemplateResponseFieldAvgTextLength implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateResponseSignerRole.php
+++ b/sdks/php/src/Model/TemplateResponseSignerRole.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateResponseSignerRole Class Doc Comment
@@ -283,7 +284,7 @@ class TemplateResponseSignerRole implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class TemplateResponseSignerRole implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class TemplateResponseSignerRole implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class TemplateResponseSignerRole implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class TemplateResponseSignerRole implements ModelInterface, ArrayAccess, JsonSer
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateUpdateFilesRequest.php
+++ b/sdks/php/src/Model/TemplateUpdateFilesRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -420,7 +421,7 @@ class TemplateUpdateFilesRequest implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -433,7 +434,7 @@ class TemplateUpdateFilesRequest implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -447,7 +448,7 @@ class TemplateUpdateFilesRequest implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -464,7 +465,7 @@ class TemplateUpdateFilesRequest implements ModelInterface, ArrayAccess, JsonSer
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -477,7 +478,7 @@ class TemplateUpdateFilesRequest implements ModelInterface, ArrayAccess, JsonSer
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateUpdateFilesResponse.php
+++ b/sdks/php/src/Model/TemplateUpdateFilesResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateUpdateFilesResponse Class Doc Comment
@@ -253,7 +254,7 @@ class TemplateUpdateFilesResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -266,7 +267,7 @@ class TemplateUpdateFilesResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -280,7 +281,7 @@ class TemplateUpdateFilesResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -297,7 +298,7 @@ class TemplateUpdateFilesResponse implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -310,7 +311,7 @@ class TemplateUpdateFilesResponse implements ModelInterface, ArrayAccess, JsonSe
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/TemplateUpdateFilesResponseTemplate.php
+++ b/sdks/php/src/Model/TemplateUpdateFilesResponseTemplate.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * TemplateUpdateFilesResponseTemplate Class Doc Comment
@@ -284,7 +285,7 @@ class TemplateUpdateFilesResponseTemplate implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -297,7 +298,7 @@ class TemplateUpdateFilesResponseTemplate implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -311,7 +312,7 @@ class TemplateUpdateFilesResponseTemplate implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -328,7 +329,7 @@ class TemplateUpdateFilesResponseTemplate implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -341,7 +342,7 @@ class TemplateUpdateFilesResponseTemplate implements ModelInterface, ArrayAccess
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/UnclaimedDraftCreateEmbeddedRequest.php
+++ b/sdks/php/src/Model/UnclaimedDraftCreateEmbeddedRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -1361,7 +1362,7 @@ class UnclaimedDraftCreateEmbeddedRequest implements ModelInterface, ArrayAccess
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1374,7 +1375,7 @@ class UnclaimedDraftCreateEmbeddedRequest implements ModelInterface, ArrayAccess
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -1388,7 +1389,7 @@ class UnclaimedDraftCreateEmbeddedRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1405,7 +1406,7 @@ class UnclaimedDraftCreateEmbeddedRequest implements ModelInterface, ArrayAccess
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1418,7 +1419,7 @@ class UnclaimedDraftCreateEmbeddedRequest implements ModelInterface, ArrayAccess
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/UnclaimedDraftCreateEmbeddedWithTemplateRequest.php
+++ b/sdks/php/src/Model/UnclaimedDraftCreateEmbeddedWithTemplateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -1127,7 +1128,7 @@ class UnclaimedDraftCreateEmbeddedWithTemplateRequest implements ModelInterface,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1140,7 +1141,7 @@ class UnclaimedDraftCreateEmbeddedWithTemplateRequest implements ModelInterface,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -1154,7 +1155,7 @@ class UnclaimedDraftCreateEmbeddedWithTemplateRequest implements ModelInterface,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1171,7 +1172,7 @@ class UnclaimedDraftCreateEmbeddedWithTemplateRequest implements ModelInterface,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1184,7 +1185,7 @@ class UnclaimedDraftCreateEmbeddedWithTemplateRequest implements ModelInterface,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/UnclaimedDraftCreateRequest.php
+++ b/sdks/php/src/Model/UnclaimedDraftCreateRequest.php
@@ -32,6 +32,7 @@ use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use InvalidArgumentException;
 use JsonSerializable;
+use ReturnTypeWillChange;
 use SplFileObject;
 
 /**
@@ -998,7 +999,7 @@ class UnclaimedDraftCreateRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -1011,7 +1012,7 @@ class UnclaimedDraftCreateRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -1025,7 +1026,7 @@ class UnclaimedDraftCreateRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -1042,7 +1043,7 @@ class UnclaimedDraftCreateRequest implements ModelInterface, ArrayAccess, JsonSe
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -1055,7 +1056,7 @@ class UnclaimedDraftCreateRequest implements ModelInterface, ArrayAccess, JsonSe
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/UnclaimedDraftCreateResponse.php
+++ b/sdks/php/src/Model/UnclaimedDraftCreateResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * UnclaimedDraftCreateResponse Class Doc Comment
@@ -283,7 +284,7 @@ class UnclaimedDraftCreateResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -296,7 +297,7 @@ class UnclaimedDraftCreateResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -310,7 +311,7 @@ class UnclaimedDraftCreateResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -327,7 +328,7 @@ class UnclaimedDraftCreateResponse implements ModelInterface, ArrayAccess, JsonS
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -340,7 +341,7 @@ class UnclaimedDraftCreateResponse implements ModelInterface, ArrayAccess, JsonS
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/UnclaimedDraftEditAndResendRequest.php
+++ b/sdks/php/src/Model/UnclaimedDraftEditAndResendRequest.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * UnclaimedDraftEditAndResendRequest Class Doc Comment
@@ -466,7 +467,7 @@ class UnclaimedDraftEditAndResendRequest implements ModelInterface, ArrayAccess,
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -479,7 +480,7 @@ class UnclaimedDraftEditAndResendRequest implements ModelInterface, ArrayAccess,
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -493,7 +494,7 @@ class UnclaimedDraftEditAndResendRequest implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -510,7 +511,7 @@ class UnclaimedDraftEditAndResendRequest implements ModelInterface, ArrayAccess,
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -523,7 +524,7 @@ class UnclaimedDraftEditAndResendRequest implements ModelInterface, ArrayAccess,
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/UnclaimedDraftResponse.php
+++ b/sdks/php/src/Model/UnclaimedDraftResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * UnclaimedDraftResponse Class Doc Comment
@@ -404,7 +405,7 @@ class UnclaimedDraftResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -417,7 +418,7 @@ class UnclaimedDraftResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -431,7 +432,7 @@ class UnclaimedDraftResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -448,7 +449,7 @@ class UnclaimedDraftResponse implements ModelInterface, ArrayAccess, JsonSeriali
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -461,7 +462,7 @@ class UnclaimedDraftResponse implements ModelInterface, ArrayAccess, JsonSeriali
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/src/Model/WarningResponse.php
+++ b/sdks/php/src/Model/WarningResponse.php
@@ -31,6 +31,7 @@ namespace Dropbox\Sign\Model;
 use ArrayAccess;
 use Dropbox\Sign\ObjectSerializer;
 use JsonSerializable;
+use ReturnTypeWillChange;
 
 /**
  * WarningResponse Class Doc Comment
@@ -290,7 +291,7 @@ class WarningResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -303,7 +304,7 @@ class WarningResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -317,7 +318,7 @@ class WarningResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -334,7 +335,7 @@ class WarningResponse implements ModelInterface, ArrayAccess, JsonSerializable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -347,7 +348,7 @@ class WarningResponse implements ModelInterface, ArrayAccess, JsonSerializable
      * @return scalar|object|array|null returns data which can be serialized by json_encode(), which is a value
      *                                  of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return ObjectSerializer::sanitizeForSerialization($this);

--- a/sdks/php/templates/model.mustache
+++ b/sdks/php/templates/model.mustache
@@ -27,6 +27,7 @@ use \ArrayAccess;
 {{/parentSchema}}
 {{/isEnum}}
 use \{{invokerPackage}}\ObjectSerializer;
+use ReturnTypeWillChange;
 
 /**
  * {{classname}} Class Doc Comment

--- a/sdks/php/templates/model_generic.mustache
+++ b/sdks/php/templates/model_generic.mustache
@@ -409,7 +409,7 @@
      *
      * @return boolean
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->container[$offset]);
@@ -422,7 +422,7 @@
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->container[$offset] ?? null;
@@ -436,7 +436,7 @@
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (is_null($offset)) {
@@ -453,7 +453,7 @@
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->container[$offset]);
@@ -466,7 +466,7 @@
      * @return scalar|object|array|null Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
        return ObjectSerializer::sanitizeForSerialization($this);


### PR DESCRIPTION
Running `./vendor/bin/php-cs-fixer fix --verbose` in docker on mac is significantly slower than on linux or using a native PHP install on host.

## Using docker PHP

`./generate-sdks -t php` results in:

> Fixed all files in 175.466 seconds, 28.000 MB memory used

## Using native PHP on host

`PHP_USE_NATIVE=1 ./generate-sdks -t php` results in:

> Fixed all files in 21.700 seconds, 32.000 MB memory used

A noticeable 2.5 minute difference.