### PR TITLE
update the create template response docs with the correct sub object

### DIFF
--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -7870,7 +7870,7 @@ components:
           items:
             type: string
         allow_reassign:
-          description: '_t__TemplateCreateEmbeddedDraft::ALLOW_REASSIGN'
+          description: '_t__TemplateCreate::ALLOW_REASSIGN'
           type: boolean
           default: false
         attachments:
@@ -10317,7 +10317,7 @@ components:
     TemplateCreateResponse:
       properties:
         template:
-          $ref: '#/components/schemas/TemplateCreateResponse'
+          $ref: '#/components/schemas/TemplateCreateResponseTemplate'
         warnings:
           description: '_t__WarningResponse::LIST_DESCRIPTION'
           type: array

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -11101,7 +11101,7 @@ components:
     TemplateCreateResponse:
       properties:
         template:
-          $ref: '#/components/schemas/TemplateCreateResponse'
+          $ref: '#/components/schemas/TemplateCreateResponseTemplate'
         warnings:
           description: 'A list of warnings.'
           type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11079,7 +11079,7 @@ components:
     TemplateCreateResponse:
       properties:
         template:
-          $ref: '#/components/schemas/TemplateCreateResponse'
+          $ref: '#/components/schemas/TemplateCreateResponseTemplate'
         warnings:
           description: 'A list of warnings.'
           type: array

--- a/sdks/dotnet/docs/TemplateCreateResponse.md
+++ b/sdks/dotnet/docs/TemplateCreateResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Template** | [**TemplateCreateResponse**](TemplateCreateResponse.md) |    | [optional] 
+**Template** | [**TemplateCreateResponseTemplate**](TemplateCreateResponseTemplate.md) |    | [optional] 
 **Warnings** | [**List&lt;WarningResponse&gt;**](WarningResponse.md) |  A list of warnings.  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/sdks/dotnet/src/Dropbox.Sign/Model/TemplateCreateResponse.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Model/TemplateCreateResponse.cs
@@ -43,7 +43,7 @@ namespace Dropbox.Sign.Model
         /// </summary>
         /// <param name="template">template.</param>
         /// <param name="warnings">A list of warnings..</param>
-        public TemplateCreateResponse(TemplateCreateResponse template = default(TemplateCreateResponse), List<WarningResponse> warnings = default(List<WarningResponse>))
+        public TemplateCreateResponse(TemplateCreateResponseTemplate template = default(TemplateCreateResponseTemplate), List<WarningResponse> warnings = default(List<WarningResponse>))
         {
             
             this.Template = template;
@@ -70,7 +70,7 @@ namespace Dropbox.Sign.Model
         /// Gets or Sets Template
         /// </summary>
         [DataMember(Name = "template", EmitDefaultValue = true)]
-        public TemplateCreateResponse Template { get; set; }
+        public TemplateCreateResponseTemplate Template { get; set; }
 
         /// <summary>
         /// A list of warnings.
@@ -164,7 +164,7 @@ namespace Dropbox.Sign.Model
             types.Add(new OpenApiType(){
                 Name = "template",
                 Property = "Template",
-                Type = "TemplateCreateResponse",
+                Type = "TemplateCreateResponseTemplate",
                 Value = Template,
             });
             types.Add(new OpenApiType(){

--- a/sdks/java/docs/TemplateCreateResponse.md
+++ b/sdks/java/docs/TemplateCreateResponse.md
@@ -8,7 +8,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `template` | [```TemplateCreateResponse```](TemplateCreateResponse.md) |    |  |
+| `template` | [```TemplateCreateResponseTemplate```](TemplateCreateResponseTemplate.md) |    |  |
 | `warnings` | [```List<WarningResponse>```](WarningResponse.md) |  A list of warnings.  |  |
 
 

--- a/sdks/java/src/main/java/com/dropbox/sign/model/TemplateCreateResponse.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/model/TemplateCreateResponse.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.HashMap;
+import com.dropbox.sign.model.TemplateCreateResponseTemplate;
 import com.dropbox.sign.model.WarningResponse;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,7 +46,7 @@ import com.dropbox.sign.ApiException;
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class TemplateCreateResponse {
   public static final String JSON_PROPERTY_TEMPLATE = "template";
-  private TemplateCreateResponse template;
+  private TemplateCreateResponseTemplate template;
 
   public static final String JSON_PROPERTY_WARNINGS = "warnings";
   private List<WarningResponse> warnings = null;
@@ -68,7 +69,7 @@ public class TemplateCreateResponse {
     );
   }
 
-  public TemplateCreateResponse template(TemplateCreateResponse template) {
+  public TemplateCreateResponse template(TemplateCreateResponseTemplate template) {
     this.template = template;
     return this;
   }
@@ -82,14 +83,14 @@ public class TemplateCreateResponse {
   @JsonProperty(JSON_PROPERTY_TEMPLATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public TemplateCreateResponse getTemplate() {
+  public TemplateCreateResponseTemplate getTemplate() {
     return template;
   }
 
 
   @JsonProperty(JSON_PROPERTY_TEMPLATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setTemplate(TemplateCreateResponse template) {
+  public void setTemplate(TemplateCreateResponseTemplate template) {
     this.template = template;
   }
 

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -26492,7 +26492,7 @@ TemplateCreateResponse.attributeTypeMap = [
   {
     name: "template",
     baseName: "template",
-    type: "TemplateCreateResponse"
+    type: "TemplateCreateResponseTemplate"
   },
   {
     name: "warnings",

--- a/sdks/node/docs/model/TemplateCreateResponse.md
+++ b/sdks/node/docs/model/TemplateCreateResponse.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `template` | [```TemplateCreateResponse```](TemplateCreateResponse.md) |    |  |
+| `template` | [```TemplateCreateResponseTemplate```](TemplateCreateResponseTemplate.md) |    |  |
 | `warnings` | [```Array<WarningResponse>```](WarningResponse.md) |  A list of warnings.  |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/node/model/templateCreateResponse.ts
+++ b/sdks/node/model/templateCreateResponse.ts
@@ -23,10 +23,11 @@
  */
 
 import { RequestFile, AttributeTypeMap, ObjectSerializer } from "./";
+import { TemplateCreateResponseTemplate } from "./templateCreateResponseTemplate";
 import { WarningResponse } from "./warningResponse";
 
 export class TemplateCreateResponse {
-  "template"?: TemplateCreateResponse;
+  "template"?: TemplateCreateResponseTemplate;
   /**
    * A list of warnings.
    */
@@ -38,7 +39,7 @@ export class TemplateCreateResponse {
     {
       name: "template",
       baseName: "template",
-      type: "TemplateCreateResponse",
+      type: "TemplateCreateResponseTemplate",
     },
     {
       name: "warnings",

--- a/sdks/node/types/model/templateCreateResponse.d.ts
+++ b/sdks/node/types/model/templateCreateResponse.d.ts
@@ -1,7 +1,8 @@
 import { AttributeTypeMap } from "./";
+import { TemplateCreateResponseTemplate } from "./templateCreateResponseTemplate";
 import { WarningResponse } from "./warningResponse";
 export declare class TemplateCreateResponse {
-    "template"?: TemplateCreateResponse;
+    "template"?: TemplateCreateResponseTemplate;
     "warnings"?: Array<WarningResponse>;
     static discriminator: string | undefined;
     static attributeTypeMap: AttributeTypeMap;

--- a/sdks/php/docs/Model/TemplateCreateResponse.md
+++ b/sdks/php/docs/Model/TemplateCreateResponse.md
@@ -6,7 +6,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `template` | [```\Dropbox\Sign\Model\TemplateCreateResponse```](TemplateCreateResponse.md) |    |  |
+| `template` | [```\Dropbox\Sign\Model\TemplateCreateResponseTemplate```](TemplateCreateResponseTemplate.md) |    |  |
 | `warnings` | [```\Dropbox\Sign\Model\WarningResponse[]```](WarningResponse.md) |  A list of warnings.  |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/php/src/Model/TemplateCreateResponse.php
+++ b/sdks/php/src/Model/TemplateCreateResponse.php
@@ -61,7 +61,7 @@ class TemplateCreateResponse implements ModelInterface, ArrayAccess, JsonSeriali
      * @var string[]
      */
     protected static $openAPITypes = [
-        'template' => '\Dropbox\Sign\Model\TemplateCreateResponse',
+        'template' => '\Dropbox\Sign\Model\TemplateCreateResponseTemplate',
         'warnings' => '\Dropbox\Sign\Model\WarningResponse[]',
     ];
 
@@ -232,7 +232,7 @@ class TemplateCreateResponse implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Gets template
      *
-     * @return TemplateCreateResponse|null
+     * @return TemplateCreateResponseTemplate|null
      */
     public function getTemplate()
     {
@@ -242,11 +242,11 @@ class TemplateCreateResponse implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Sets template
      *
-     * @param TemplateCreateResponse|null $template template
+     * @param TemplateCreateResponseTemplate|null $template template
      *
      * @return self
      */
-    public function setTemplate(?TemplateCreateResponse $template)
+    public function setTemplate(?TemplateCreateResponseTemplate $template)
     {
         $this->container['template'] = $template;
 

--- a/sdks/python/docs/TemplateCreateResponse.md
+++ b/sdks/python/docs/TemplateCreateResponse.md
@@ -6,7 +6,7 @@
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| `template` | [```TemplateCreateResponse```](TemplateCreateResponse.md) |    |  |
+| `template` | [```TemplateCreateResponseTemplate```](TemplateCreateResponseTemplate.md) |    |  |
 | `warnings` | [```[WarningResponse]```](WarningResponse.md) |  A list of warnings.  |  |
 
 

--- a/sdks/python/dropbox_sign/model/template_create_response.py
+++ b/sdks/python/dropbox_sign/model/template_create_response.py
@@ -33,11 +33,14 @@ from dropbox_sign.model_utils import (  # noqa: F401
 )
 from dropbox_sign.exceptions import ApiAttributeError
 if TYPE_CHECKING:
+    from dropbox_sign.model.template_create_response_template import TemplateCreateResponseTemplate
     from dropbox_sign.model.warning_response import WarningResponse
 
 
 def lazy_import():
+    from dropbox_sign.model.template_create_response_template import TemplateCreateResponseTemplate
     from dropbox_sign.model.warning_response import WarningResponse
+    globals()['TemplateCreateResponseTemplate'] = TemplateCreateResponseTemplate
     globals()['WarningResponse'] = WarningResponse
 
 
@@ -94,7 +97,7 @@ class TemplateCreateResponse(ModelNormal):
         """
         lazy_import()
         return {
-            'template': (TemplateCreateResponse,),  # noqa: E501
+            'template': (TemplateCreateResponseTemplate,),  # noqa: E501
             'warnings': ([WarningResponse],),  # noqa: E501
         }
 
@@ -129,11 +132,11 @@ class TemplateCreateResponse(ModelNormal):
     _composed_schemas = {}
 
     @property
-    def template(self) -> TemplateCreateResponse:
+    def template(self) -> TemplateCreateResponseTemplate:
         return self.get("template")
 
     @template.setter
-    def template(self, value: TemplateCreateResponse):
+    def template(self, value: TemplateCreateResponseTemplate):
         setattr(self, "template", value)
 
     @property
@@ -180,7 +183,7 @@ class TemplateCreateResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            template (TemplateCreateResponse): [optional]  # noqa: E501
+            template (TemplateCreateResponseTemplate): [optional]  # noqa: E501
             warnings ([WarningResponse]): A list of warnings.. [optional]  # noqa: E501
         """
 
@@ -263,7 +266,7 @@ class TemplateCreateResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            template (TemplateCreateResponse): [optional]  # noqa: E501
+            template (TemplateCreateResponseTemplate): [optional]  # noqa: E501
             warnings ([WarningResponse]): A list of warnings.. [optional]  # noqa: E501
         """
 

--- a/sdks/ruby/docs/TemplateCreateResponse.md
+++ b/sdks/ruby/docs/TemplateCreateResponse.md
@@ -6,6 +6,6 @@
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| `template` | [```TemplateCreateResponse```](TemplateCreateResponse.md) |    |  |
+| `template` | [```TemplateCreateResponseTemplate```](TemplateCreateResponseTemplate.md) |    |  |
 | `warnings` | [```Array<WarningResponse>```](WarningResponse.md) |  A list of warnings.  |  |
 

--- a/sdks/ruby/lib/dropbox-sign/models/template_create_response.rb
+++ b/sdks/ruby/lib/dropbox-sign/models/template_create_response.rb
@@ -18,7 +18,7 @@ end
 
 module Dropbox::Sign
   class TemplateCreateResponse
-    # @return [TemplateCreateResponse]
+    # @return [TemplateCreateResponseTemplate]
     attr_accessor :template
 
     # A list of warnings.
@@ -46,7 +46,7 @@ module Dropbox::Sign
     # Attribute type mapping.
     def self.openapi_types
       {
-        :'template' => :'TemplateCreateResponse',
+        :'template' => :'TemplateCreateResponseTemplate',
         :'warnings' => :'Array<WarningResponse>'
       }
     end


### PR DESCRIPTION
Previously the TemplateCreateResponse had a circular link to itself, now it points to TemplateCreateResponseTemplate