### PR TITLE
Add force_download param to signature request files call 

### DIFF
--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2235,6 +2235,7 @@ paths:
           schema:
             type: boolean
             default: true
+          x-hideOn: sdk
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2228,6 +2228,13 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: '_t__SignatureRequestFiles::FORCE_DOWNLOAD'
+          schema:
+            type: integer
+            default: 1
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2235,6 +2235,7 @@ paths:
           schema:
             type: integer
             default: 1
+          x-hideOn: sdk
       responses:
         '200':
           description: 'successful operation'
@@ -4957,6 +4958,7 @@ paths:
           schema:
             type: integer
             default: 1
+          x-hideOn: sdk
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2235,7 +2235,6 @@ paths:
           schema:
             type: boolean
             default: true
-          x-hideOn: sdk
       responses:
         '200':
           description: 'successful operation'
@@ -2458,6 +2457,13 @@ paths:
           schema:
             type: string
           example: fa5c8a0b0f492d768749333ad6fcc214c111e967
+        -
+          name: force_download
+          in: query
+          description: '_t__SignatureRequestFiles::FORCE_DOWNLOAD'
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'successful operation'
@@ -4944,6 +4950,13 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: '_t__TemplateFiles::FORCE_DOWNLOAD'
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'successful operation'
@@ -5164,6 +5177,13 @@ paths:
           schema:
             type: string
           example: f57db65d3f933b5316d398057a36176831451a35
+        -
+          name: force_download
+          in: query
+          description: '_t__TemplateFiles::FORCE_DOWNLOAD'
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2233,8 +2233,8 @@ paths:
           in: query
           description: '_t__SignatureRequestFiles::FORCE_DOWNLOAD'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         '200':
           description: 'successful operation'
@@ -2462,8 +2462,8 @@ paths:
           in: query
           description: '_t__SignatureRequestFiles::FORCE_DOWNLOAD'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         '200':
           description: 'successful operation'
@@ -4955,8 +4955,8 @@ paths:
           in: query
           description: '_t__TemplateFiles::FORCE_DOWNLOAD'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         '200':
           description: 'successful operation'
@@ -5182,8 +5182,8 @@ paths:
           in: query
           description: '_t__TemplateFiles::FORCE_DOWNLOAD'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2233,8 +2233,8 @@ paths:
           in: query
           description: '_t__SignatureRequestFiles::FORCE_DOWNLOAD'
           schema:
-            type: integer
-            default: 1
+            type: boolean
+            default: true
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -2228,14 +2228,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: '_t__SignatureRequestFiles::FORCE_DOWNLOAD'
-          schema:
-            type: integer
-            default: 1
-          x-hideOn: sdk
       responses:
         '200':
           description: 'successful operation'
@@ -4951,14 +4943,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: '_t__TemplateFiles::FORCE_DOWNLOAD'
-          schema:
-            type: integer
-            default: 1
-          x-hideOn: sdk
       responses:
         '200':
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2255,6 +2255,16 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: |-
+            If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+
+            **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
+          schema:
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2259,12 +2259,12 @@ paths:
           name: force_download
           in: query
           description: |-
-            If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+            By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
 
             **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
           schema:
-            type: integer
-            default: 1
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2258,10 +2258,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -2493,10 +2493,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -5005,10 +5005,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -5238,10 +5238,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2255,13 +2255,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
-          schema:
-            type: integer
-            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -5002,13 +4995,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
-          schema:
-            type: integer
-            default: 1
       responses:
         200:
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2255,16 +2255,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: |-
-            By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
-
-            **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
-          schema:
-            type: boolean
-            default: true
       responses:
         200:
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2255,6 +2255,13 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'
@@ -2483,6 +2490,13 @@ paths:
           schema:
             type: string
           example: fa5c8a0b0f492d768749333ad6fcc214c111e967
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'
@@ -4988,6 +5002,13 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'
@@ -5214,6 +5235,13 @@ paths:
           schema:
             type: string
           example: f57db65d3f933b5316d398057a36176831451a35
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2486,7 +2486,7 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
+          description: 'By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
             type: integer
             default: 1
@@ -5224,7 +5224,7 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
+          description: 'By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
             type: integer
             default: 1

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2255,6 +2255,16 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: |-
+            If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+
+            **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
+          schema:
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2259,12 +2259,12 @@ paths:
           name: force_download
           in: query
           description: |-
-            If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+            By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
 
             **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
           schema:
-            type: integer
-            default: 1
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2258,10 +2258,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -2493,10 +2493,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -5005,10 +5005,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'
@@ -5238,10 +5238,10 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
-            type: boolean
-            default: true
+            type: integer
+            default: 1
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2255,14 +2255,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
-          schema:
-            type: integer
-            default: 1
-          x-hideOn: sdk
       responses:
         200:
           description: 'successful operation'
@@ -5003,14 +4995,6 @@ paths:
             enum:
               - pdf
               - zip
-        -
-          name: force_download
-          in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
-          schema:
-            type: integer
-            default: 1
-          x-hideOn: sdk
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2265,6 +2265,7 @@ paths:
           schema:
             type: boolean
             default: true
+          x-hideOn: sdk
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2258,14 +2258,10 @@ paths:
         -
           name: force_download
           in: query
-          description: |-
-            By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
-
-            **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
           schema:
             type: boolean
             default: true
-          x-hideOn: sdk
       responses:
         200:
           description: 'successful operation'
@@ -2494,6 +2490,13 @@ paths:
           schema:
             type: string
           example: fa5c8a0b0f492d768749333ad6fcc214c111e967
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'
@@ -4999,6 +5002,13 @@ paths:
             enum:
               - pdf
               - zip
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'
@@ -5225,6 +5235,13 @@ paths:
           schema:
             type: string
           example: f57db65d3f933b5316d398057a36176831451a35
+        -
+          name: force_download
+          in: query
+          description: 'By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.'
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2262,6 +2262,7 @@ paths:
           schema:
             type: integer
             default: 1
+          x-hideOn: sdk
       responses:
         200:
           description: 'successful operation'
@@ -5009,6 +5010,7 @@ paths:
           schema:
             type: integer
             default: 1
+          x-hideOn: sdk
       responses:
         200:
           description: 'successful operation'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2486,7 +2486,7 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
+          description: 'By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
             type: integer
             default: 1
@@ -5224,7 +5224,7 @@ paths:
         -
           name: force_download
           in: query
-          description: 'By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.'
+          description: 'By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.'
           schema:
             type: integer
             default: 1

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -651,7 +651,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfiles"></a>
 # **SignatureRequestFiles**
-> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, bool? forceDownload = null)
+> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null)
 
 Download Files
 
@@ -707,7 +707,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Download Files
-    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -726,7 +726,6 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] |
-| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -651,7 +651,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfiles"></a>
 # **SignatureRequestFiles**
-> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, int? forceDownload = null)
+> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null)
 
 Download Files
 
@@ -707,7 +707,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Download Files
-    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -726,7 +726,6 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] |
-| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -651,7 +651,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfiles"></a>
 # **SignatureRequestFiles**
-> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, int? forceDownload = null)
+> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, bool? forceDownload = null)
 
 Download Files
 
@@ -726,7 +726,7 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] |
-| **forceDownload** | **int?** | If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1] |
+| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -651,7 +651,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfiles"></a>
 # **SignatureRequestFiles**
-> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, bool? forceDownload = null)
+> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, int? forceDownload = null)
 
 Download Files
 
@@ -726,7 +726,7 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] |
-| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 
@@ -847,7 +847,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfilesasfileurl"></a>
 # **SignatureRequestFilesAsFileUrl**
-> FileResponse SignatureRequestFilesAsFileUrl (string signatureRequestId, bool? forceDownload = null)
+> FileResponse SignatureRequestFilesAsFileUrl (string signatureRequestId, int? forceDownload = null)
 
 Download Files as File Url
 
@@ -917,7 +917,7 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
-| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -916,7 +916,7 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
-| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
+| **forceDownload** | **int?** | By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -651,7 +651,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfiles"></a>
 # **SignatureRequestFiles**
-> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null)
+> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, int? forceDownload = null)
 
 Download Files
 
@@ -707,7 +707,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Download Files
-    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
+    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -726,6 +726,7 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] |
+| **forceDownload** | **int?** | If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -651,7 +651,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfiles"></a>
 # **SignatureRequestFiles**
-> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null)
+> System.IO.Stream SignatureRequestFiles (string signatureRequestId, string? fileType = null, bool? forceDownload = null)
 
 Download Files
 
@@ -707,7 +707,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Download Files
-    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
+    ApiResponse<System.IO.Stream> response = apiInstance.SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -726,6 +726,7 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] |
+| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 
@@ -846,7 +847,7 @@ catch (ApiException e)
 
 <a name="signaturerequestfilesasfileurl"></a>
 # **SignatureRequestFilesAsFileUrl**
-> FileResponse SignatureRequestFilesAsFileUrl (string signatureRequestId)
+> FileResponse SignatureRequestFilesAsFileUrl (string signatureRequestId, bool? forceDownload = null)
 
 Download Files as File Url
 
@@ -898,7 +899,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Download Files as File Url
-    ApiResponse<FileResponse> response = apiInstance.SignatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId);
+    ApiResponse<FileResponse> response = apiInstance.SignatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -916,6 +917,7 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **signatureRequestId** | **string** | The id of the SignatureRequest to retrieve. |  |
+| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/TemplateApi.md
+++ b/sdks/dotnet/docs/TemplateApi.md
@@ -489,7 +489,7 @@ void (empty response body)
 
 <a name="templatefiles"></a>
 # **TemplateFiles**
-> System.IO.Stream TemplateFiles (string templateId, string? fileType = null)
+> System.IO.Stream TemplateFiles (string templateId, string? fileType = null, bool? forceDownload = null)
 
 Get Template Files
 
@@ -545,7 +545,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get Template Files
-    ApiResponse<System.IO.Stream> response = apiInstance.TemplateFilesWithHttpInfo(templateId, fileType);
+    ApiResponse<System.IO.Stream> response = apiInstance.TemplateFilesWithHttpInfo(templateId, fileType, forceDownload);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -564,6 +564,7 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **templateId** | **string** | The id of the template files to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional]  |
+| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 
@@ -684,7 +685,7 @@ catch (ApiException e)
 
 <a name="templatefilesasfileurl"></a>
 # **TemplateFilesAsFileUrl**
-> FileResponse TemplateFilesAsFileUrl (string templateId)
+> FileResponse TemplateFilesAsFileUrl (string templateId, bool? forceDownload = null)
 
 Get Template Files as File Url
 
@@ -736,7 +737,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get Template Files as File Url
-    ApiResponse<FileResponse> response = apiInstance.TemplateFilesAsFileUrlWithHttpInfo(templateId);
+    ApiResponse<FileResponse> response = apiInstance.TemplateFilesAsFileUrlWithHttpInfo(templateId, forceDownload);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -754,6 +755,7 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **templateId** | **string** | The id of the template files to retrieve. |  |
+| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/TemplateApi.md
+++ b/sdks/dotnet/docs/TemplateApi.md
@@ -754,7 +754,7 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **templateId** | **string** | The id of the template files to retrieve. |  |
-| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
+| **forceDownload** | **int?** | By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/TemplateApi.md
+++ b/sdks/dotnet/docs/TemplateApi.md
@@ -489,7 +489,7 @@ void (empty response body)
 
 <a name="templatefiles"></a>
 # **TemplateFiles**
-> System.IO.Stream TemplateFiles (string templateId, string? fileType = null, bool? forceDownload = null)
+> System.IO.Stream TemplateFiles (string templateId, string? fileType = null, int? forceDownload = null)
 
 Get Template Files
 
@@ -564,7 +564,7 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **templateId** | **string** | The id of the template files to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional]  |
-| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 
@@ -685,7 +685,7 @@ catch (ApiException e)
 
 <a name="templatefilesasfileurl"></a>
 # **TemplateFilesAsFileUrl**
-> FileResponse TemplateFilesAsFileUrl (string templateId, bool? forceDownload = null)
+> FileResponse TemplateFilesAsFileUrl (string templateId, int? forceDownload = null)
 
 Get Template Files as File Url
 
@@ -755,7 +755,7 @@ catch (ApiException e)
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
 | **templateId** | **string** | The id of the template files to retrieve. |  |
-| **forceDownload** | **bool?** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/docs/TemplateApi.md
+++ b/sdks/dotnet/docs/TemplateApi.md
@@ -489,7 +489,7 @@ void (empty response body)
 
 <a name="templatefiles"></a>
 # **TemplateFiles**
-> System.IO.Stream TemplateFiles (string templateId, string? fileType = null, int? forceDownload = null)
+> System.IO.Stream TemplateFiles (string templateId, string? fileType = null)
 
 Get Template Files
 
@@ -545,7 +545,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get Template Files
-    ApiResponse<System.IO.Stream> response = apiInstance.TemplateFilesWithHttpInfo(templateId, fileType, forceDownload);
+    ApiResponse<System.IO.Stream> response = apiInstance.TemplateFilesWithHttpInfo(templateId, fileType);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -564,7 +564,6 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **templateId** | **string** | The id of the template files to retrieve. |  |
 | **fileType** | **string?** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional]  |
-| **forceDownload** | **int?** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -151,10 +151,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
+        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files
@@ -165,10 +164,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -554,11 +552,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files
@@ -569,11 +566,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -1843,12 +1839,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
+        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
             return localVarResponse.Data;
         }
 
@@ -1858,10 +1853,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1897,10 +1891,6 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
-            }
-            if (forceDownload != null)
-            {
-                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1938,13 +1928,12 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1954,11 +1943,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1996,10 +1984,6 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
-            }
-            if (forceDownload != null)
-            {
-                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -151,10 +151,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
+        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files
@@ -165,10 +164,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -552,11 +550,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files
@@ -567,11 +564,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -1839,12 +1835,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
+        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
             return localVarResponse.Data;
         }
 
@@ -1854,10 +1849,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1893,10 +1887,6 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
-            }
-            if (forceDownload != null)
-            {
-                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1934,13 +1924,12 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1950,11 +1939,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1992,10 +1980,6 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
-            }
-            if (forceDownload != null)
-            {
-                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -151,10 +151,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
+        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files
@@ -165,10 +165,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -552,11 +552,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files
@@ -567,11 +567,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -1839,10 +1839,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
+        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
         {
             Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
             return localVarResponse.Data;
@@ -1854,10 +1854,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1934,11 +1934,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -1950,11 +1950,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -151,9 +151,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
+        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files
@@ -164,9 +165,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -550,10 +552,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files
@@ -564,10 +567,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -1835,11 +1839,12 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
+        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
             return localVarResponse.Data;
         }
 
@@ -1849,9 +1854,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1887,6 +1893,10 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
+            }
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1924,12 +1934,13 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1939,10 +1950,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1980,6 +1992,10 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
+            }
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -151,9 +151,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
+        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files
@@ -164,9 +165,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -198,9 +200,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, int operationIndex = 0);
+        FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files as File Url
@@ -210,9 +213,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, int operationIndex = 0);
+        ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0);
         /// <summary>
         /// Get Signature Request
         /// </summary>
@@ -550,10 +554,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files
@@ -564,10 +569,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -601,10 +607,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files as File Url
@@ -614,10 +621,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Signature Request
         /// </summary>
@@ -1835,11 +1843,12 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
+        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
             return localVarResponse.Data;
         }
 
@@ -1849,9 +1858,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1887,6 +1897,10 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
+            }
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1924,12 +1938,13 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1939,10 +1954,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1980,6 +1996,10 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
+            }
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -2184,11 +2204,12 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        public FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, int operationIndex = 0)
+        public FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = SignatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId);
+            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = SignatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload);
             return localVarResponse.Data;
         }
 
@@ -2197,9 +2218,10 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        public Dropbox.Sign.Client.ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -2230,6 +2252,10 @@ namespace Dropbox.Sign.Api
             }
 
             localVarRequestOptions.PathParameters.Add("signature_request_id", Dropbox.Sign.Client.ClientUtils.ParameterToString(signatureRequestId)); // path parameter
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
+            }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFilesAsFileUrl";
             localVarRequestOptions.OperationIndex = operationIndex;
 
@@ -2265,12 +2291,13 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        public async System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = await SignatureRequestFilesAsFileUrlWithHttpInfoAsync(signatureRequestId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = await SignatureRequestFilesAsFileUrlWithHttpInfoAsync(signatureRequestId, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2279,10 +2306,11 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -2315,6 +2343,10 @@ namespace Dropbox.Sign.Api
             }
 
             localVarRequestOptions.PathParameters.Add("signature_request_id", Dropbox.Sign.Client.ClientUtils.ParameterToString(signatureRequestId)); // path parameter
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
+            }
             localVarRequestOptions.Operation = "SignatureRequestApi.SignatureRequestFilesAsFileUrl";
             localVarRequestOptions.OperationIndex = operationIndex;
 

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -151,10 +151,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
+        System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files
@@ -165,10 +165,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -200,10 +200,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0);
+        FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0);
 
         /// <summary>
         /// Download Files as File Url
@@ -213,10 +213,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0);
+        ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0);
         /// <summary>
         /// Get Signature Request
         /// </summary>
@@ -554,11 +554,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files
@@ -569,11 +569,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Download Files as Data Uri
         /// </summary>
@@ -607,11 +607,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Download Files as File Url
@@ -621,11 +621,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Signature Request
         /// </summary>
@@ -1843,10 +1843,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
+        public System.IO.Stream SignatureRequestFiles(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
         {
             Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = SignatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
             return localVarResponse.Data;
@@ -1858,10 +1858,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> SignatureRequestFilesWithHttpInfo(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -1938,11 +1938,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> SignatureRequestFilesAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await SignatureRequestFilesWithHttpInfoAsync(signatureRequestId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -1954,11 +1954,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> SignatureRequestFilesWithHttpInfoAsync(string signatureRequestId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -2204,10 +2204,10 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        public FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0)
+        public FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0)
         {
             Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = SignatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload);
             return localVarResponse.Data;
@@ -2218,10 +2218,10 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        public Dropbox.Sign.Client.ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0)
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)
@@ -2291,11 +2291,11 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        public async System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<FileResponse> SignatureRequestFilesAsFileUrlAsync(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = await SignatureRequestFilesAsFileUrlWithHttpInfoAsync(signatureRequestId, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -2306,11 +2306,11 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> SignatureRequestFilesAsFileUrlWithHttpInfoAsync(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'signatureRequestId' is set
             if (signatureRequestId == null)

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -198,7 +198,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
         FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0);
@@ -211,7 +211,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
         ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0);
@@ -603,7 +603,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
@@ -617,7 +617,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
@@ -2188,7 +2188,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
         public FileResponse SignatureRequestFilesAsFileUrl(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0)
@@ -2202,7 +2202,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
         public Dropbox.Sign.Client.ApiResponse<FileResponse> SignatureRequestFilesAsFileUrlWithHttpInfo(string signatureRequestId, int? forceDownload = default(int?), int operationIndex = 0)
@@ -2275,7 +2275,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
@@ -2290,7 +2290,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>

--- a/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
@@ -177,7 +177,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
         FileResponse TemplateFilesAsFileUrl(string templateId, int? forceDownload = default(int?), int operationIndex = 0);
@@ -190,7 +190,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
         ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, int? forceDownload = default(int?), int operationIndex = 0);
@@ -467,7 +467,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
@@ -481,7 +481,7 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
@@ -1800,7 +1800,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
         public FileResponse TemplateFilesAsFileUrl(string templateId, int? forceDownload = default(int?), int operationIndex = 0)
@@ -1814,7 +1814,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
         public Dropbox.Sign.Client.ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, int? forceDownload = default(int?), int operationIndex = 0)
@@ -1887,7 +1887,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
@@ -1902,7 +1902,7 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
+        /// <param name="forceDownload">By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>

--- a/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
@@ -130,10 +130,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
+        System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int operationIndex = 0);
 
         /// <summary>
         /// Get Template Files
@@ -144,10 +143,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int operationIndex = 0);
         /// <summary>
         /// Get Template Files as Data Uri
         /// </summary>
@@ -418,11 +416,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get Template Files
@@ -433,11 +430,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Template Files as Data Uri
         /// </summary>
@@ -1455,12 +1451,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
+        public System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = TemplateFilesWithHttpInfo(templateId, fileType, forceDownload);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = TemplateFilesWithHttpInfo(templateId, fileType);
             return localVarResponse.Data;
         }
 
@@ -1470,10 +1465,9 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int operationIndex = 0)
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1509,10 +1503,6 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
-            }
-            if (forceDownload != null)
-            {
-                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "TemplateApi.TemplateFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1550,13 +1540,12 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await TemplateFilesWithHttpInfoAsync(templateId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await TemplateFilesWithHttpInfoAsync(templateId, fileType, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1566,11 +1555,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1608,10 +1596,6 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
-            }
-            if (forceDownload != null)
-            {
-                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "TemplateApi.TemplateFiles";
             localVarRequestOptions.OperationIndex = operationIndex;

--- a/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
@@ -130,10 +130,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
+        System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
 
         /// <summary>
         /// Get Template Files
@@ -144,10 +144,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0);
         /// <summary>
         /// Get Template Files as Data Uri
         /// </summary>
@@ -179,10 +179,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        FileResponse TemplateFilesAsFileUrl(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0);
+        FileResponse TemplateFilesAsFileUrl(string templateId, int? forceDownload = default(int?), int operationIndex = 0);
 
         /// <summary>
         /// Get Template Files as File Url
@@ -192,10 +192,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0);
+        ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, int? forceDownload = default(int?), int operationIndex = 0);
         /// <summary>
         /// Get Template
         /// </summary>
@@ -418,11 +418,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get Template Files
@@ -433,11 +433,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Template Files as Data Uri
         /// </summary>
@@ -471,11 +471,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get Template Files as File Url
@@ -485,11 +485,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Template
         /// </summary>
@@ -1455,10 +1455,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
+        public System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
         {
             Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = TemplateFilesWithHttpInfo(templateId, fileType, forceDownload);
             return localVarResponse.Data;
@@ -1470,10 +1470,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0)
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1550,11 +1550,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await TemplateFilesWithHttpInfoAsync(templateId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -1566,11 +1566,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1816,10 +1816,10 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        public FileResponse TemplateFilesAsFileUrl(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0)
+        public FileResponse TemplateFilesAsFileUrl(string templateId, int? forceDownload = default(int?), int operationIndex = 0)
         {
             Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = TemplateFilesAsFileUrlWithHttpInfo(templateId, forceDownload);
             return localVarResponse.Data;
@@ -1830,10 +1830,10 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        public Dropbox.Sign.Client.ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, int? forceDownload = default(int?), int operationIndex = 0)
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1903,11 +1903,11 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        public async System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = await TemplateFilesAsFileUrlWithHttpInfoAsync(templateId, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
@@ -1918,11 +1918,11 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
-        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, int? forceDownload = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)

--- a/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/TemplateApi.cs
@@ -130,9 +130,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int operationIndex = 0);
+        System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
 
         /// <summary>
         /// Get Template Files
@@ -143,9 +144,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int operationIndex = 0);
+        ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0);
         /// <summary>
         /// Get Template Files as Data Uri
         /// </summary>
@@ -177,9 +179,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        FileResponse TemplateFilesAsFileUrl(string templateId, int operationIndex = 0);
+        FileResponse TemplateFilesAsFileUrl(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0);
 
         /// <summary>
         /// Get Template Files as File Url
@@ -189,9 +192,10 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, int operationIndex = 0);
+        ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0);
         /// <summary>
         /// Get Template
         /// </summary>
@@ -414,10 +418,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get Template Files
@@ -428,10 +433,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Template Files as Data Uri
         /// </summary>
@@ -465,10 +471,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get Template Files as File Url
@@ -478,10 +485,11 @@ namespace Dropbox.Sign.Api
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get Template
         /// </summary>
@@ -1447,11 +1455,12 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>System.IO.Stream</returns>
-        public System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), int operationIndex = 0)
+        public System.IO.Stream TemplateFiles(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = TemplateFilesWithHttpInfo(templateId, fileType);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = TemplateFilesWithHttpInfo(templateId, fileType, forceDownload);
             return localVarResponse.Data;
         }
 
@@ -1461,9 +1470,10 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of System.IO.Stream</returns>
-        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<System.IO.Stream> TemplateFilesWithHttpInfo(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0)
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1499,6 +1509,10 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
+            }
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "TemplateApi.TemplateFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1536,12 +1550,13 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of System.IO.Stream</returns>
-        public async System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<System.IO.Stream> TemplateFilesAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await TemplateFilesWithHttpInfoAsync(templateId, fileType, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<System.IO.Stream> localVarResponse = await TemplateFilesWithHttpInfoAsync(templateId, fileType, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1551,10 +1566,11 @@ namespace Dropbox.Sign.Api
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
         /// <param name="fileType">Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (System.IO.Stream)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<System.IO.Stream>> TemplateFilesWithHttpInfoAsync(string templateId, string? fileType = default(string?), bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1592,6 +1608,10 @@ namespace Dropbox.Sign.Api
             if (fileType != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "file_type", fileType));
+            }
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
             }
             localVarRequestOptions.Operation = "TemplateApi.TemplateFiles";
             localVarRequestOptions.OperationIndex = operationIndex;
@@ -1796,11 +1816,12 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>FileResponse</returns>
-        public FileResponse TemplateFilesAsFileUrl(string templateId, int operationIndex = 0)
+        public FileResponse TemplateFilesAsFileUrl(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0)
         {
-            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = TemplateFilesAsFileUrlWithHttpInfo(templateId);
+            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = TemplateFilesAsFileUrlWithHttpInfo(templateId, forceDownload);
             return localVarResponse.Data;
         }
 
@@ -1809,9 +1830,10 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of FileResponse</returns>
-        public Dropbox.Sign.Client.ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, int operationIndex = 0)
+        public Dropbox.Sign.Client.ApiResponse<FileResponse> TemplateFilesAsFileUrlWithHttpInfo(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0)
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1842,6 +1864,10 @@ namespace Dropbox.Sign.Api
             }
 
             localVarRequestOptions.PathParameters.Add("template_id", Dropbox.Sign.Client.ClientUtils.ParameterToString(templateId)); // path parameter
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
+            }
             localVarRequestOptions.Operation = "TemplateApi.TemplateFilesAsFileUrl";
             localVarRequestOptions.OperationIndex = operationIndex;
 
@@ -1877,12 +1903,13 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of FileResponse</returns>
-        public async System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<FileResponse> TemplateFilesAsFileUrlAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = await TemplateFilesAsFileUrlWithHttpInfoAsync(templateId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Dropbox.Sign.Client.ApiResponse<FileResponse> localVarResponse = await TemplateFilesAsFileUrlWithHttpInfoAsync(templateId, forceDownload, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1891,10 +1918,11 @@ namespace Dropbox.Sign.Api
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="templateId">The id of the template files to retrieve.</param>
+        /// <param name="forceDownload">By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (FileResponse)</returns>
-        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Dropbox.Sign.Client.ApiResponse<FileResponse>> TemplateFilesAsFileUrlWithHttpInfoAsync(string templateId, bool? forceDownload = default(bool?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'templateId' is set
             if (templateId == null)
@@ -1927,6 +1955,10 @@ namespace Dropbox.Sign.Api
             }
 
             localVarRequestOptions.PathParameters.Add("template_id", Dropbox.Sign.Client.ClientUtils.ParameterToString(templateId)); // path parameter
+            if (forceDownload != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Dropbox.Sign.Client.ClientUtils.ParameterToMultiMap("", "force_download", forceDownload));
+            }
             localVarRequestOptions.Operation = "TemplateApi.TemplateFilesAsFileUrl";
             localVarRequestOptions.OperationIndex = operationIndex;
 

--- a/sdks/java/bin/generate-overload-methods.php
+++ b/sdks/java/bin/generate-overload-methods.php
@@ -150,12 +150,10 @@ class GenerateOverloadMethods
 
             $data = "{$type} {$name} = ";
 
-            if ($value === null) {
-                $data .= "null;";
-            } elseif (strtolower(trim($type)) === 'string') {
+            if ($value !== null && strtolower(trim($type)) === 'string') {
                 $data .= '"' . $value . '";';
-            } elseif (strtolower(trim($type)) === 'boolean') {
-                $data .= $value ? "true;" : "false;";
+            } elseif ($value === null) {
+                $data .= "null;";
             } else {
                 $data .= "{$value};";
             }

--- a/sdks/java/bin/generate-overload-methods.php
+++ b/sdks/java/bin/generate-overload-methods.php
@@ -150,10 +150,12 @@ class GenerateOverloadMethods
 
             $data = "{$type} {$name} = ";
 
-            if ($value !== null && strtolower(trim($type)) === 'string') {
-                $data .= '"' . $value . '";';
-            } elseif ($value === null) {
+            if ($value === null) {
                 $data .= "null;";
+            } elseif (strtolower(trim($type)) === 'string') {
+                $data .= '"' . $value . '";';
+            } elseif (strtolower(trim($type)) === 'boolean') {
+                $data .= $value ? "true;" : "false;";
             } else {
                 $data .= "{$value};";
             }

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -781,7 +781,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
- **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
+ **forceDownload** | **Integer**| By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -559,7 +559,7 @@ Name | Type | Description  | Notes
 
 ## signatureRequestFiles
 
-> File signatureRequestFiles(signatureRequestId, fileType, forceDownload)
+> File signatureRequestFiles(signatureRequestId, fileType)
 
 Download Files
 
@@ -619,7 +619,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] [enum: pdf, zip]
- **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -559,7 +559,7 @@ Name | Type | Description  | Notes
 
 ## signatureRequestFiles
 
-> File signatureRequestFiles(signatureRequestId, fileType)
+> File signatureRequestFiles(signatureRequestId, fileType, forceDownload)
 
 Download Files
 
@@ -619,6 +619,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] [enum: pdf, zip]
+ **forceDownload** | **Integer**| If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -619,7 +619,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] [enum: pdf, zip]
- **forceDownload** | **Integer**| If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1]
+ **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true]
 
 ### Return type
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -559,7 +559,7 @@ Name | Type | Description  | Notes
 
 ## signatureRequestFiles
 
-> File signatureRequestFiles(signatureRequestId, fileType, forceDownload)
+> File signatureRequestFiles(signatureRequestId, fileType)
 
 Download Files
 
@@ -619,7 +619,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] [enum: pdf, zip]
- **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true]
 
 ### Return type
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -619,7 +619,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] [enum: pdf, zip]
- **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
+ **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 
@@ -782,7 +782,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
- **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
+ **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -559,7 +559,7 @@ Name | Type | Description  | Notes
 
 ## signatureRequestFiles
 
-> File signatureRequestFiles(signatureRequestId, fileType)
+> File signatureRequestFiles(signatureRequestId, fileType, forceDownload)
 
 Download Files
 
@@ -619,6 +619,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to pdf] [enum: pdf, zip]
+ **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
 
 ### Return type
 
@@ -723,7 +724,7 @@ Name | Type | Description  | Notes
 
 ## signatureRequestFilesAsFileUrl
 
-> FileResponse signatureRequestFilesAsFileUrl(signatureRequestId)
+> FileResponse signatureRequestFilesAsFileUrl(signatureRequestId, forceDownload)
 
 Download Files as File Url
 
@@ -781,6 +782,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **signatureRequestId** | **String**| The id of the SignatureRequest to retrieve. |
+ **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
 
 ### Return type
 

--- a/sdks/java/docs/TemplateApi.md
+++ b/sdks/java/docs/TemplateApi.md
@@ -624,7 +624,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **templateId** | **String**| The id of the template files to retrieve. |
- **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
+ **forceDownload** | **Integer**| By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/docs/TemplateApi.md
+++ b/sdks/java/docs/TemplateApi.md
@@ -402,7 +402,7 @@ null (empty response body)
 
 ## templateFiles
 
-> File templateFiles(templateId, fileType)
+> File templateFiles(templateId, fileType, forceDownload)
 
 Get Template Files
 
@@ -462,6 +462,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **templateId** | **String**| The id of the template files to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [enum: pdf, zip]
+ **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
 
 ### Return type
 
@@ -566,7 +567,7 @@ Name | Type | Description  | Notes
 
 ## templateFilesAsFileUrl
 
-> FileResponse templateFilesAsFileUrl(templateId)
+> FileResponse templateFilesAsFileUrl(templateId, forceDownload)
 
 Get Template Files as File Url
 
@@ -624,6 +625,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **templateId** | **String**| The id of the template files to retrieve. |
+ **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
 
 ### Return type
 

--- a/sdks/java/docs/TemplateApi.md
+++ b/sdks/java/docs/TemplateApi.md
@@ -402,7 +402,7 @@ null (empty response body)
 
 ## templateFiles
 
-> File templateFiles(templateId, fileType, forceDownload)
+> File templateFiles(templateId, fileType)
 
 Get Template Files
 
@@ -462,7 +462,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **templateId** | **String**| The id of the template files to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [enum: pdf, zip]
- **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/docs/TemplateApi.md
+++ b/sdks/java/docs/TemplateApi.md
@@ -462,7 +462,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **templateId** | **String**| The id of the template files to retrieve. |
  **fileType** | **String**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [enum: pdf, zip]
- **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
+ **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 
@@ -625,7 +625,7 @@ public class Example {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **templateId** | **String**| The id of the template files to retrieve. |
- **forceDownload** | **Boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true]
+ **forceDownload** | **Integer**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1]
 
 ### Return type
 

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -437,7 +437,6 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -447,47 +446,27 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File signatureRequestFiles(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
+  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String)
    */
   public File signatureRequestFiles(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Integer forceDownload = 1;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Integer forceDownload = 1;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
-  }
-
-  /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
-   */
-  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
-    Integer forceDownload = 1;
-
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
-  }
-
-  /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
-   */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
-    Integer forceDownload = 1;
-
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
   }
 
 
@@ -496,7 +475,6 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -506,13 +484,10 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
     
     if (fileType == null) {
         fileType = "pdf";
-    }
-    if (forceDownload == null) {
-        forceDownload = 1;
     }
     Object localVarPostBody = null;
     
@@ -532,7 +507,6 @@ public class SignatureRequestApi {
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "file_type", fileType));
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -437,7 +437,6 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -447,47 +446,27 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File signatureRequestFiles(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
+  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String)
    */
   public File signatureRequestFiles(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Boolean forceDownload = true;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Boolean forceDownload = true;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
-  }
-
-  /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
-   */
-  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
-    Boolean forceDownload = true;
-
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
-  }
-
-  /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
-   */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
-    Boolean forceDownload = true;
-
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
   }
 
 
@@ -496,7 +475,6 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -506,13 +484,10 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
     
     if (fileType == null) {
         fileType = "pdf";
-    }
-    if (forceDownload == null) {
-        forceDownload = true;
     }
     Object localVarPostBody = null;
     
@@ -532,7 +507,6 @@ public class SignatureRequestApi {
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "file_type", fileType));
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -437,7 +437,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -447,45 +447,45 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File signatureRequestFiles(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
+  public File signatureRequestFiles(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
    */
   public File signatureRequestFiles(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Integer forceDownload = 1;
+    Boolean forceDownload = true;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Integer forceDownload = 1;
+    Boolean forceDownload = true;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
    */
   public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
-    Integer forceDownload = 1;
+    Boolean forceDownload = true;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
-    Integer forceDownload = 1;
+    Boolean forceDownload = true;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
   }
@@ -496,7 +496,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -506,13 +506,13 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
     
     if (fileType == null) {
         fileType = "pdf";
     }
     if (forceDownload == null) {
-        forceDownload = 1;
+        forceDownload = true;
     }
     Object localVarPostBody = null;
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -613,7 +613,7 @@ public class SignatureRequestApi {
    * Download Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+   * @param forceDownload By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return FileResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -651,7 +651,7 @@ public class SignatureRequestApi {
    * Download Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+   * @param forceDownload By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;FileResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -437,6 +437,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
+   * @param forceDownload If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -446,27 +447,47 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
+  public File signatureRequestFiles(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
    */
   public File signatureRequestFiles(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
+    Integer forceDownload = 1;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
+    Integer forceDownload = 1;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+  }
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
+   */
+  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
+    Integer forceDownload = 1;
+
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
+  }
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
+   */
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
+    Integer forceDownload = 1;
+
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
   }
 
 
@@ -475,6 +496,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
+   * @param forceDownload If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -484,10 +506,13 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
     
     if (fileType == null) {
         fileType = "pdf";
+    }
+    if (forceDownload == null) {
+        forceDownload = 1;
     }
     Object localVarPostBody = null;
     
@@ -507,6 +532,7 @@ public class SignatureRequestApi {
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "file_type", fileType));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -437,7 +437,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -447,45 +447,45 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File signatureRequestFiles(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
+  public File signatureRequestFiles(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
    */
   public File signatureRequestFiles(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Integer)
    */
   public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Integer)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
   }
@@ -496,7 +496,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -506,13 +506,13 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Integer forceDownload) throws ApiException {
     
     if (fileType == null) {
         fileType = "pdf";
     }
     if (forceDownload == null) {
-        forceDownload = true;
+        forceDownload = 1;
     }
     Object localVarPostBody = null;
     
@@ -639,7 +639,7 @@ public class SignatureRequestApi {
    * Download Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return FileResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -649,25 +649,25 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public FileResponse signatureRequestFilesAsFileUrl(String signatureRequestId, Boolean forceDownload) throws ApiException {
+  public FileResponse signatureRequestFilesAsFileUrl(String signatureRequestId, Integer forceDownload) throws ApiException {
     return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesAsFileUrl(String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFilesAsFileUrl(String, Integer)
    */
   public FileResponse signatureRequestFilesAsFileUrl(String signatureRequestId) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesAsFileUrlWithHttpInfo(String, Boolean)
+   * @see SignatureRequestApi#signatureRequestFilesAsFileUrlWithHttpInfo(String, Integer)
    */
   public ApiResponse<FileResponse> signatureRequestFilesAsFileUrlWithHttpInfo(String signatureRequestId) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload);
   }
@@ -677,7 +677,7 @@ public class SignatureRequestApi {
    * Download Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;FileResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -687,10 +687,10 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<FileResponse> signatureRequestFilesAsFileUrlWithHttpInfo(String signatureRequestId, Boolean forceDownload) throws ApiException {
+  public ApiResponse<FileResponse> signatureRequestFilesAsFileUrlWithHttpInfo(String signatureRequestId, Integer forceDownload) throws ApiException {
     
     if (forceDownload == null) {
-        forceDownload = true;
+        forceDownload = 1;
     }
     Object localVarPostBody = null;
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -437,6 +437,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -446,27 +447,47 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
+  public File signatureRequestFiles(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
 
   /**
-   * @see SignatureRequestApi#signatureRequestFiles(String, String)
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
    */
   public File signatureRequestFiles(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
+    Boolean forceDownload = true;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType).getData();
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String)
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
    */
   public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId) throws ApiException {
     String fileType = "pdf";
+    Boolean forceDownload = true;
 
-    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType);
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
+  }
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFiles(String, String, Boolean)
+   */
+  public File signatureRequestFiles(String signatureRequestId, String fileType) throws ApiException {
+    Boolean forceDownload = true;
+
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload).getData();
+  }
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFilesWithHttpInfo(String, String, Boolean)
+   */
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
+    Boolean forceDownload = true;
+
+    return signatureRequestFilesWithHttpInfo(signatureRequestId, fileType, forceDownload);
   }
 
 
@@ -475,6 +496,7 @@ public class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to pdf)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -484,10 +506,13 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType) throws ApiException {
+  public ApiResponse<File> signatureRequestFilesWithHttpInfo(String signatureRequestId, String fileType, Boolean forceDownload) throws ApiException {
     
     if (fileType == null) {
         fileType = "pdf";
+    }
+    if (forceDownload == null) {
+        forceDownload = true;
     }
     Object localVarPostBody = null;
     
@@ -507,6 +532,7 @@ public class SignatureRequestApi {
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "file_type", fileType));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     
@@ -613,6 +639,7 @@ public class SignatureRequestApi {
    * Download Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return FileResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -622,8 +649,27 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
+  public FileResponse signatureRequestFilesAsFileUrl(String signatureRequestId, Boolean forceDownload) throws ApiException {
+    return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload).getData();
+  }
+
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFilesAsFileUrl(String, Boolean)
+   */
   public FileResponse signatureRequestFilesAsFileUrl(String signatureRequestId) throws ApiException {
-    return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId).getData();
+    Boolean forceDownload = true;
+
+    return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload).getData();
+  }
+
+  /**
+   * @see SignatureRequestApi#signatureRequestFilesAsFileUrlWithHttpInfo(String, Boolean)
+   */
+  public ApiResponse<FileResponse> signatureRequestFilesAsFileUrlWithHttpInfo(String signatureRequestId) throws ApiException {
+    Boolean forceDownload = true;
+
+    return signatureRequestFilesAsFileUrlWithHttpInfo(signatureRequestId, forceDownload);
   }
 
 
@@ -631,6 +677,7 @@ public class SignatureRequestApi {
    * Download Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
    * @param signatureRequestId The id of the SignatureRequest to retrieve. (required)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return ApiResponse&lt;FileResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -640,8 +687,11 @@ public class SignatureRequestApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<FileResponse> signatureRequestFilesAsFileUrlWithHttpInfo(String signatureRequestId) throws ApiException {
+  public ApiResponse<FileResponse> signatureRequestFilesAsFileUrlWithHttpInfo(String signatureRequestId, Boolean forceDownload) throws ApiException {
     
+    if (forceDownload == null) {
+        forceDownload = true;
+    }
     Object localVarPostBody = null;
     
     // verify the required parameter 'signatureRequestId' is set
@@ -659,6 +709,7 @@ public class SignatureRequestApi {
     Map<String, String> localVarCookieParams = new HashMap<String, String>();
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -369,7 +369,6 @@ public class TemplateApi {
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -379,47 +378,27 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File templateFiles(String templateId, String fileType, Integer forceDownload) throws ApiException {
-    return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
+  public File templateFiles(String templateId, String fileType) throws ApiException {
+    return templateFilesWithHttpInfo(templateId, fileType).getData();
   }
 
 
   /**
-   * @see TemplateApi#templateFiles(String, String, Integer)
+   * @see TemplateApi#templateFiles(String, String)
    */
   public File templateFiles(String templateId) throws ApiException {
     String fileType = null;
-    Integer forceDownload = 1;
 
-    return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
+    return templateFilesWithHttpInfo(templateId, fileType).getData();
   }
 
   /**
-   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Integer)
+   * @see TemplateApi#templateFilesWithHttpInfo(String, String)
    */
   public ApiResponse<File> templateFilesWithHttpInfo(String templateId) throws ApiException {
     String fileType = null;
-    Integer forceDownload = 1;
 
-    return templateFilesWithHttpInfo(templateId, fileType, forceDownload);
-  }
-
-  /**
-   * @see TemplateApi#templateFiles(String, String, Integer)
-   */
-  public File templateFiles(String templateId, String fileType) throws ApiException {
-    Integer forceDownload = 1;
-
-    return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
-  }
-
-  /**
-   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Integer)
-   */
-  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType) throws ApiException {
-    Integer forceDownload = 1;
-
-    return templateFilesWithHttpInfo(templateId, fileType, forceDownload);
+    return templateFilesWithHttpInfo(templateId, fileType);
   }
 
 
@@ -428,7 +407,6 @@ public class TemplateApi {
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -438,11 +416,8 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType, Integer forceDownload) throws ApiException {
+  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType) throws ApiException {
     
-    if (forceDownload == null) {
-        forceDownload = 1;
-    }
     Object localVarPostBody = null;
     
     // verify the required parameter 'templateId' is set
@@ -461,7 +436,6 @@ public class TemplateApi {
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "file_type", fileType));
-    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -542,7 +542,7 @@ public class TemplateApi {
    * Get Template Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+   * @param forceDownload By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return FileResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -580,7 +580,7 @@ public class TemplateApi {
    * Get Template Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+   * @param forceDownload By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;FileResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -369,6 +369,7 @@ public class TemplateApi {
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -378,27 +379,47 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File templateFiles(String templateId, String fileType) throws ApiException {
-    return templateFilesWithHttpInfo(templateId, fileType).getData();
+  public File templateFiles(String templateId, String fileType, Boolean forceDownload) throws ApiException {
+    return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
   }
 
 
   /**
-   * @see TemplateApi#templateFiles(String, String)
+   * @see TemplateApi#templateFiles(String, String, Boolean)
    */
   public File templateFiles(String templateId) throws ApiException {
     String fileType = null;
+    Boolean forceDownload = true;
 
-    return templateFilesWithHttpInfo(templateId, fileType).getData();
+    return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see TemplateApi#templateFilesWithHttpInfo(String, String)
+   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Boolean)
    */
   public ApiResponse<File> templateFilesWithHttpInfo(String templateId) throws ApiException {
     String fileType = null;
+    Boolean forceDownload = true;
 
-    return templateFilesWithHttpInfo(templateId, fileType);
+    return templateFilesWithHttpInfo(templateId, fileType, forceDownload);
+  }
+
+  /**
+   * @see TemplateApi#templateFiles(String, String, Boolean)
+   */
+  public File templateFiles(String templateId, String fileType) throws ApiException {
+    Boolean forceDownload = true;
+
+    return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
+  }
+
+  /**
+   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Boolean)
+   */
+  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType) throws ApiException {
+    Boolean forceDownload = true;
+
+    return templateFilesWithHttpInfo(templateId, fileType, forceDownload);
   }
 
 
@@ -407,6 +428,7 @@ public class TemplateApi {
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -416,8 +438,11 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType) throws ApiException {
+  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType, Boolean forceDownload) throws ApiException {
     
+    if (forceDownload == null) {
+        forceDownload = true;
+    }
     Object localVarPostBody = null;
     
     // verify the required parameter 'templateId' is set
@@ -436,6 +461,7 @@ public class TemplateApi {
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "file_type", fileType));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     
@@ -542,6 +568,7 @@ public class TemplateApi {
    * Get Template Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return FileResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -551,8 +578,27 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
+  public FileResponse templateFilesAsFileUrl(String templateId, Boolean forceDownload) throws ApiException {
+    return templateFilesAsFileUrlWithHttpInfo(templateId, forceDownload).getData();
+  }
+
+
+  /**
+   * @see TemplateApi#templateFilesAsFileUrl(String, Boolean)
+   */
   public FileResponse templateFilesAsFileUrl(String templateId) throws ApiException {
-    return templateFilesAsFileUrlWithHttpInfo(templateId).getData();
+    Boolean forceDownload = true;
+
+    return templateFilesAsFileUrlWithHttpInfo(templateId, forceDownload).getData();
+  }
+
+  /**
+   * @see TemplateApi#templateFilesAsFileUrlWithHttpInfo(String, Boolean)
+   */
+  public ApiResponse<FileResponse> templateFilesAsFileUrlWithHttpInfo(String templateId) throws ApiException {
+    Boolean forceDownload = true;
+
+    return templateFilesAsFileUrlWithHttpInfo(templateId, forceDownload);
   }
 
 
@@ -560,6 +606,7 @@ public class TemplateApi {
    * Get Template Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
    * @return ApiResponse&lt;FileResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -569,8 +616,11 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<FileResponse> templateFilesAsFileUrlWithHttpInfo(String templateId) throws ApiException {
+  public ApiResponse<FileResponse> templateFilesAsFileUrlWithHttpInfo(String templateId, Boolean forceDownload) throws ApiException {
     
+    if (forceDownload == null) {
+        forceDownload = true;
+    }
     Object localVarPostBody = null;
     
     // verify the required parameter 'templateId' is set
@@ -588,6 +638,7 @@ public class TemplateApi {
     Map<String, String> localVarCookieParams = new HashMap<String, String>();
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "force_download", forceDownload));
 
     
     

--- a/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/TemplateApi.java
@@ -369,7 +369,7 @@ public class TemplateApi {
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return File
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -379,45 +379,45 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public File templateFiles(String templateId, String fileType, Boolean forceDownload) throws ApiException {
+  public File templateFiles(String templateId, String fileType, Integer forceDownload) throws ApiException {
     return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
   }
 
 
   /**
-   * @see TemplateApi#templateFiles(String, String, Boolean)
+   * @see TemplateApi#templateFiles(String, String, Integer)
    */
   public File templateFiles(String templateId) throws ApiException {
     String fileType = null;
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Boolean)
+   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Integer)
    */
   public ApiResponse<File> templateFilesWithHttpInfo(String templateId) throws ApiException {
     String fileType = null;
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return templateFilesWithHttpInfo(templateId, fileType, forceDownload);
   }
 
   /**
-   * @see TemplateApi#templateFiles(String, String, Boolean)
+   * @see TemplateApi#templateFiles(String, String, Integer)
    */
   public File templateFiles(String templateId, String fileType) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return templateFilesWithHttpInfo(templateId, fileType, forceDownload).getData();
   }
 
   /**
-   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Boolean)
+   * @see TemplateApi#templateFilesWithHttpInfo(String, String, Integer)
    */
   public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return templateFilesWithHttpInfo(templateId, fileType, forceDownload);
   }
@@ -428,7 +428,7 @@ public class TemplateApi {
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a PDF or ZIP file.  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;File&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -438,10 +438,10 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType, Boolean forceDownload) throws ApiException {
+  public ApiResponse<File> templateFilesWithHttpInfo(String templateId, String fileType, Integer forceDownload) throws ApiException {
     
     if (forceDownload == null) {
-        forceDownload = true;
+        forceDownload = 1;
     }
     Object localVarPostBody = null;
     
@@ -568,7 +568,7 @@ public class TemplateApi {
    * Get Template Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return FileResponse
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -578,25 +578,25 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public FileResponse templateFilesAsFileUrl(String templateId, Boolean forceDownload) throws ApiException {
+  public FileResponse templateFilesAsFileUrl(String templateId, Integer forceDownload) throws ApiException {
     return templateFilesAsFileUrlWithHttpInfo(templateId, forceDownload).getData();
   }
 
 
   /**
-   * @see TemplateApi#templateFilesAsFileUrl(String, Boolean)
+   * @see TemplateApi#templateFilesAsFileUrl(String, Integer)
    */
   public FileResponse templateFilesAsFileUrl(String templateId) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return templateFilesAsFileUrlWithHttpInfo(templateId, forceDownload).getData();
   }
 
   /**
-   * @see TemplateApi#templateFilesAsFileUrlWithHttpInfo(String, Boolean)
+   * @see TemplateApi#templateFilesAsFileUrlWithHttpInfo(String, Integer)
    */
   public ApiResponse<FileResponse> templateFilesAsFileUrlWithHttpInfo(String templateId) throws ApiException {
-    Boolean forceDownload = true;
+    Integer forceDownload = 1;
 
     return templateFilesAsFileUrlWithHttpInfo(templateId, forceDownload);
   }
@@ -606,7 +606,7 @@ public class TemplateApi {
    * Get Template Files as File Url
    * Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
    * @param templateId The id of the template files to retrieve. (required)
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
    * @return ApiResponse&lt;FileResponse&gt;
    * @throws ApiException if fails to make API call
    * @http.response.details
@@ -616,10 +616,10 @@ public class TemplateApi {
        <tr><td> 4XX </td><td> failed_operation </td><td>  -  </td></tr>
      </table>
    */
-  public ApiResponse<FileResponse> templateFilesAsFileUrlWithHttpInfo(String templateId, Boolean forceDownload) throws ApiException {
+  public ApiResponse<FileResponse> templateFilesAsFileUrlWithHttpInfo(String templateId, Integer forceDownload) throws ApiException {
     
     if (forceDownload == null) {
-        forceDownload = true;
+        forceDownload = 1;
     }
     Object localVarPostBody = null;
     

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -927,13 +927,11 @@ export class SignatureRequestApi {
    * @summary Download Files
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async signatureRequestFiles(
     signatureRequestId: string,
     fileType?: "pdf" | "zip",
-    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -968,13 +966,6 @@ export class SignatureRequestApi {
       localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
         fileType,
         "'pdf' | 'zip'"
-      );
-    }
-
-    if (forceDownload !== undefined) {
-      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
-        forceDownload,
-        "number"
       );
     }
 

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -927,11 +927,13 @@ export class SignatureRequestApi {
    * @summary Download Files
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async signatureRequestFiles(
     signatureRequestId: string,
     fileType?: "pdf" | "zip",
+    forceDownload?: boolean,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -966,6 +968,13 @@ export class SignatureRequestApi {
       localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
         fileType,
         "'pdf' | 'zip'"
+      );
+    }
+
+    if (forceDownload !== undefined) {
+      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+        forceDownload,
+        "boolean"
       );
     }
 
@@ -1203,10 +1212,12 @@ export class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the `signature_request_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead.
    * @summary Download Files as File Url
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async signatureRequestFilesAsFileUrl(
     signatureRequestId: string,
+    forceDownload?: boolean,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<FileResponse>> {
     const localVarPath =
@@ -1234,6 +1245,13 @@ export class SignatureRequestApi {
     if (signatureRequestId === null || signatureRequestId === undefined) {
       throw new Error(
         "Required parameter signatureRequestId was null or undefined when calling signatureRequestFilesAsFileUrl."
+      );
+    }
+
+    if (forceDownload !== undefined) {
+      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+        forceDownload,
+        "boolean"
       );
     }
 

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -927,13 +927,13 @@ export class SignatureRequestApi {
    * @summary Download Files
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async signatureRequestFiles(
     signatureRequestId: string,
     fileType?: "pdf" | "zip",
-    forceDownload?: boolean,
+    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -974,7 +974,7 @@ export class SignatureRequestApi {
     if (forceDownload !== undefined) {
       localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
         forceDownload,
-        "boolean"
+        "number"
       );
     }
 
@@ -1212,12 +1212,12 @@ export class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the `signature_request_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead.
    * @summary Download Files as File Url
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async signatureRequestFilesAsFileUrl(
     signatureRequestId: string,
-    forceDownload?: boolean,
+    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<FileResponse>> {
     const localVarPath =
@@ -1251,7 +1251,7 @@ export class SignatureRequestApi {
     if (forceDownload !== undefined) {
       localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
         forceDownload,
-        "boolean"
+        "number"
       );
     }
 

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -927,13 +927,13 @@ export class SignatureRequestApi {
    * @summary Download Files
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-   * @param forceDownload If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
    * @param options
    */
   public async signatureRequestFiles(
     signatureRequestId: string,
     fileType?: "pdf" | "zip",
-    forceDownload?: number,
+    forceDownload?: boolean,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -974,7 +974,7 @@ export class SignatureRequestApi {
     if (forceDownload !== undefined) {
       localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
         forceDownload,
-        "number"
+        "boolean"
       );
     }
 

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -927,11 +927,13 @@ export class SignatureRequestApi {
    * @summary Download Files
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+   * @param forceDownload If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
    * @param options
    */
   public async signatureRequestFiles(
     signatureRequestId: string,
     fileType?: "pdf" | "zip",
+    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -966,6 +968,13 @@ export class SignatureRequestApi {
       localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
         fileType,
         "'pdf' | 'zip'"
+      );
+    }
+
+    if (forceDownload !== undefined) {
+      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+        forceDownload,
+        "number"
       );
     }
 

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -1203,7 +1203,7 @@ export class SignatureRequestApi {
    * Obtain a copy of the current documents specified by the `signature_request_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead.
    * @summary Download Files as File Url
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
+   * @param forceDownload By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async signatureRequestFilesAsFileUrl(

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -927,13 +927,11 @@ export class SignatureRequestApi {
    * @summary Download Files
    * @param signatureRequestId The id of the SignatureRequest to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
    * @param options
    */
   public async signatureRequestFiles(
     signatureRequestId: string,
     fileType?: "pdf" | "zip",
-    forceDownload?: boolean,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -968,13 +966,6 @@ export class SignatureRequestApi {
       localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
         fileType,
         "'pdf' | 'zip'"
-      );
-    }
-
-    if (forceDownload !== undefined) {
-      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
-        forceDownload,
-        "boolean"
       );
     }
 

--- a/sdks/node/api/templateApi.ts
+++ b/sdks/node/api/templateApi.ts
@@ -764,13 +764,13 @@ export class TemplateApi {
    * @summary Get Template Files
    * @param templateId The id of the template files to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async templateFiles(
     templateId: string,
     fileType?: "pdf" | "zip",
-    forceDownload?: boolean,
+    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -811,7 +811,7 @@ export class TemplateApi {
     if (forceDownload !== undefined) {
       localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
         forceDownload,
-        "boolean"
+        "number"
       );
     }
 
@@ -1049,12 +1049,12 @@ export class TemplateApi {
    * Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
    * @summary Get Template Files as File Url
    * @param templateId The id of the template files to retrieve.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async templateFilesAsFileUrl(
     templateId: string,
-    forceDownload?: boolean,
+    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<FileResponse>> {
     const localVarPath =
@@ -1088,7 +1088,7 @@ export class TemplateApi {
     if (forceDownload !== undefined) {
       localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
         forceDownload,
-        "boolean"
+        "number"
       );
     }
 

--- a/sdks/node/api/templateApi.ts
+++ b/sdks/node/api/templateApi.ts
@@ -764,13 +764,11 @@ export class TemplateApi {
    * @summary Get Template Files
    * @param templateId The id of the template files to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async templateFiles(
     templateId: string,
     fileType?: "pdf" | "zip",
-    forceDownload?: number,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -805,13 +803,6 @@ export class TemplateApi {
       localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
         fileType,
         "'pdf' | 'zip'"
-      );
-    }
-
-    if (forceDownload !== undefined) {
-      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
-        forceDownload,
-        "number"
       );
     }
 

--- a/sdks/node/api/templateApi.ts
+++ b/sdks/node/api/templateApi.ts
@@ -764,11 +764,13 @@ export class TemplateApi {
    * @summary Get Template Files
    * @param templateId The id of the template files to retrieve.
    * @param fileType Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async templateFiles(
     templateId: string,
     fileType?: "pdf" | "zip",
+    forceDownload?: boolean,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<Buffer>> {
     const localVarPath =
@@ -803,6 +805,13 @@ export class TemplateApi {
       localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
         fileType,
         "'pdf' | 'zip'"
+      );
+    }
+
+    if (forceDownload !== undefined) {
+      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+        forceDownload,
+        "boolean"
       );
     }
 
@@ -1040,10 +1049,12 @@ export class TemplateApi {
    * Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
    * @summary Get Template Files as File Url
    * @param templateId The id of the template files to retrieve.
+   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async templateFilesAsFileUrl(
     templateId: string,
+    forceDownload?: boolean,
     options: optionsI = { headers: {} }
   ): Promise<returnTypeT<FileResponse>> {
     const localVarPath =
@@ -1071,6 +1082,13 @@ export class TemplateApi {
     if (templateId === null || templateId === undefined) {
       throw new Error(
         "Required parameter templateId was null or undefined when calling templateFilesAsFileUrl."
+      );
+    }
+
+    if (forceDownload !== undefined) {
+      localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+        forceDownload,
+        "boolean"
       );
     }
 

--- a/sdks/node/api/templateApi.ts
+++ b/sdks/node/api/templateApi.ts
@@ -1040,7 +1040,7 @@ export class TemplateApi {
    * Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
    * @summary Get Template Files as File Url
    * @param templateId The id of the template files to retrieve.
-   * @param forceDownload By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
+   * @param forceDownload By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
    * @param options
    */
   public async templateFilesAsFileUrl(

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -31714,7 +31714,7 @@ var SignatureRequestApi = class {
       if (forceDownload !== void 0) {
         localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
           forceDownload,
-          "number"
+          "boolean"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -31681,8 +31681,8 @@ var SignatureRequestApi = class {
       });
     });
   }
-  signatureRequestFiles(_0, _1, _2) {
-    return __async(this, arguments, function* (signatureRequestId, fileType, forceDownload, options = { headers: {} }) {
+  signatureRequestFiles(_0, _1) {
+    return __async(this, arguments, function* (signatureRequestId, fileType, options = { headers: {} }) {
       const localVarPath = this.basePath + "/signature_request/files/{signature_request_id}".replace(
         "{signature_request_id}",
         encodeURIComponent(String(signatureRequestId))
@@ -31709,12 +31709,6 @@ var SignatureRequestApi = class {
         localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
           fileType,
           "'pdf' | 'zip'"
-        );
-      }
-      if (forceDownload !== void 0) {
-        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
-          forceDownload,
-          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -34556,8 +34550,8 @@ var TemplateApi = class {
       });
     });
   }
-  templateFiles(_0, _1, _2) {
-    return __async(this, arguments, function* (templateId, fileType, forceDownload, options = { headers: {} }) {
+  templateFiles(_0, _1) {
+    return __async(this, arguments, function* (templateId, fileType, options = { headers: {} }) {
       const localVarPath = this.basePath + "/template/files/{template_id}".replace(
         "{template_id}",
         encodeURIComponent(String(templateId))
@@ -34584,12 +34578,6 @@ var TemplateApi = class {
         localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
           fileType,
           "'pdf' | 'zip'"
-        );
-      }
-      if (forceDownload !== void 0) {
-        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
-          forceDownload,
-          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -31681,8 +31681,8 @@ var SignatureRequestApi = class {
       });
     });
   }
-  signatureRequestFiles(_0, _1, _2) {
-    return __async(this, arguments, function* (signatureRequestId, fileType, forceDownload, options = { headers: {} }) {
+  signatureRequestFiles(_0, _1) {
+    return __async(this, arguments, function* (signatureRequestId, fileType, options = { headers: {} }) {
       const localVarPath = this.basePath + "/signature_request/files/{signature_request_id}".replace(
         "{signature_request_id}",
         encodeURIComponent(String(signatureRequestId))
@@ -31709,12 +31709,6 @@ var SignatureRequestApi = class {
         localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
           fileType,
           "'pdf' | 'zip'"
-        );
-      }
-      if (forceDownload !== void 0) {
-        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
-          forceDownload,
-          "boolean"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -31681,8 +31681,8 @@ var SignatureRequestApi = class {
       });
     });
   }
-  signatureRequestFiles(_0, _1) {
-    return __async(this, arguments, function* (signatureRequestId, fileType, options = { headers: {} }) {
+  signatureRequestFiles(_0, _1, _2) {
+    return __async(this, arguments, function* (signatureRequestId, fileType, forceDownload, options = { headers: {} }) {
       const localVarPath = this.basePath + "/signature_request/files/{signature_request_id}".replace(
         "{signature_request_id}",
         encodeURIComponent(String(signatureRequestId))
@@ -31709,6 +31709,12 @@ var SignatureRequestApi = class {
         localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
           fileType,
           "'pdf' | 'zip'"
+        );
+      }
+      if (forceDownload !== void 0) {
+        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+          forceDownload,
+          "boolean"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -31887,8 +31893,8 @@ var SignatureRequestApi = class {
       });
     });
   }
-  signatureRequestFilesAsFileUrl(_0) {
-    return __async(this, arguments, function* (signatureRequestId, options = { headers: {} }) {
+  signatureRequestFilesAsFileUrl(_0, _1) {
+    return __async(this, arguments, function* (signatureRequestId, forceDownload, options = { headers: {} }) {
       const localVarPath = this.basePath + "/signature_request/files_as_file_url/{signature_request_id}".replace(
         "{signature_request_id}",
         encodeURIComponent(String(signatureRequestId))
@@ -31909,6 +31915,12 @@ var SignatureRequestApi = class {
       if (signatureRequestId === null || signatureRequestId === void 0) {
         throw new Error(
           "Required parameter signatureRequestId was null or undefined when calling signatureRequestFilesAsFileUrl."
+        );
+      }
+      if (forceDownload !== void 0) {
+        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+          forceDownload,
+          "boolean"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -34544,8 +34556,8 @@ var TemplateApi = class {
       });
     });
   }
-  templateFiles(_0, _1) {
-    return __async(this, arguments, function* (templateId, fileType, options = { headers: {} }) {
+  templateFiles(_0, _1, _2) {
+    return __async(this, arguments, function* (templateId, fileType, forceDownload, options = { headers: {} }) {
       const localVarPath = this.basePath + "/template/files/{template_id}".replace(
         "{template_id}",
         encodeURIComponent(String(templateId))
@@ -34572,6 +34584,12 @@ var TemplateApi = class {
         localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
           fileType,
           "'pdf' | 'zip'"
+        );
+      }
+      if (forceDownload !== void 0) {
+        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+          forceDownload,
+          "boolean"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -34750,8 +34768,8 @@ var TemplateApi = class {
       });
     });
   }
-  templateFilesAsFileUrl(_0) {
-    return __async(this, arguments, function* (templateId, options = { headers: {} }) {
+  templateFilesAsFileUrl(_0, _1) {
+    return __async(this, arguments, function* (templateId, forceDownload, options = { headers: {} }) {
       const localVarPath = this.basePath + "/template/files_as_file_url/{template_id}".replace(
         "{template_id}",
         encodeURIComponent(String(templateId))
@@ -34772,6 +34790,12 @@ var TemplateApi = class {
       if (templateId === null || templateId === void 0) {
         throw new Error(
           "Required parameter templateId was null or undefined when calling templateFilesAsFileUrl."
+        );
+      }
+      if (forceDownload !== void 0) {
+        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+          forceDownload,
+          "boolean"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -31714,7 +31714,7 @@ var SignatureRequestApi = class {
       if (forceDownload !== void 0) {
         localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
           forceDownload,
-          "boolean"
+          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -31920,7 +31920,7 @@ var SignatureRequestApi = class {
       if (forceDownload !== void 0) {
         localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
           forceDownload,
-          "boolean"
+          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -34589,7 +34589,7 @@ var TemplateApi = class {
       if (forceDownload !== void 0) {
         localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
           forceDownload,
-          "boolean"
+          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);
@@ -34795,7 +34795,7 @@ var TemplateApi = class {
       if (forceDownload !== void 0) {
         localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
           forceDownload,
-          "boolean"
+          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -31681,8 +31681,8 @@ var SignatureRequestApi = class {
       });
     });
   }
-  signatureRequestFiles(_0, _1) {
-    return __async(this, arguments, function* (signatureRequestId, fileType, options = { headers: {} }) {
+  signatureRequestFiles(_0, _1, _2) {
+    return __async(this, arguments, function* (signatureRequestId, fileType, forceDownload, options = { headers: {} }) {
       const localVarPath = this.basePath + "/signature_request/files/{signature_request_id}".replace(
         "{signature_request_id}",
         encodeURIComponent(String(signatureRequestId))
@@ -31709,6 +31709,12 @@ var SignatureRequestApi = class {
         localVarQueryParameters["file_type"] = ObjectSerializer.serialize(
           fileType,
           "'pdf' | 'zip'"
+        );
+      }
+      if (forceDownload !== void 0) {
+        localVarQueryParameters["force_download"] = ObjectSerializer.serialize(
+          forceDownload,
+          "number"
         );
       }
       Object.assign(localVarHeaderParams, options.headers);

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -735,7 +735,7 @@ result.then(response => {
 ## `signatureRequestFiles()`
 
 ```typescript
-signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: boolean): Buffer
+signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: number): Buffer
 ```
 
 Download Files
@@ -804,7 +804,7 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 
@@ -909,7 +909,7 @@ result.then(response => {
 ## `signatureRequestFilesAsFileUrl()`
 
 ```typescript
-signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload: boolean): FileResponse
+signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload: number): FileResponse
 ```
 
 Download Files as File Url
@@ -971,7 +971,7 @@ result.then(response => {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
-| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -735,7 +735,7 @@ result.then(response => {
 ## `signatureRequestFiles()`
 
 ```typescript
-signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: boolean): Buffer
+signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip'): Buffer
 ```
 
 Download Files
@@ -804,7 +804,6 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -735,7 +735,7 @@ result.then(response => {
 ## `signatureRequestFiles()`
 
 ```typescript
-signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip'): Buffer
+signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: boolean): Buffer
 ```
 
 Download Files
@@ -804,6 +804,7 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
+| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 
@@ -908,7 +909,7 @@ result.then(response => {
 ## `signatureRequestFilesAsFileUrl()`
 
 ```typescript
-signatureRequestFilesAsFileUrl(signatureRequestId: string): FileResponse
+signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload: boolean): FileResponse
 ```
 
 Download Files as File Url
@@ -970,6 +971,7 @@ result.then(response => {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
+| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -735,7 +735,7 @@ result.then(response => {
 ## `signatureRequestFiles()`
 
 ```typescript
-signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: number): Buffer
+signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip'): Buffer
 ```
 
 Download Files
@@ -804,7 +804,6 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -970,7 +970,7 @@ result.then(response => {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
-| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
+| **forceDownload** | **number**| By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -735,7 +735,7 @@ result.then(response => {
 ## `signatureRequestFiles()`
 
 ```typescript
-signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: number): Buffer
+signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: boolean): Buffer
 ```
 
 Download Files
@@ -804,7 +804,7 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **forceDownload** | **number**| If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1] |
+| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -735,7 +735,7 @@ result.then(response => {
 ## `signatureRequestFiles()`
 
 ```typescript
-signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip'): Buffer
+signatureRequestFiles(signatureRequestId: string, fileType: 'pdf' | 'zip', forceDownload: number): Buffer
 ```
 
 Download Files
@@ -804,6 +804,7 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **signatureRequestId** | **string**| The id of the SignatureRequest to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
+| **forceDownload** | **number**| If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/docs/api/TemplateApi.md
+++ b/sdks/node/docs/api/TemplateApi.md
@@ -529,7 +529,7 @@ void (empty response body)
 ## `templateFiles()`
 
 ```typescript
-templateFiles(templateId: string, fileType: 'pdf' | 'zip'): Buffer
+templateFiles(templateId: string, fileType: 'pdf' | 'zip', forceDownload: boolean): Buffer
 ```
 
 Get Template Files
@@ -596,6 +596,7 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **templateId** | **string**| The id of the template files to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
+| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 
@@ -700,7 +701,7 @@ result.then(response => {
 ## `templateFilesAsFileUrl()`
 
 ```typescript
-templateFilesAsFileUrl(templateId: string): FileResponse
+templateFilesAsFileUrl(templateId: string, forceDownload: boolean): FileResponse
 ```
 
 Get Template Files as File Url
@@ -762,6 +763,7 @@ result.then(response => {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **templateId** | **string**| The id of the template files to retrieve. | |
+| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/node/docs/api/TemplateApi.md
+++ b/sdks/node/docs/api/TemplateApi.md
@@ -529,7 +529,7 @@ void (empty response body)
 ## `templateFiles()`
 
 ```typescript
-templateFiles(templateId: string, fileType: 'pdf' | 'zip', forceDownload: number): Buffer
+templateFiles(templateId: string, fileType: 'pdf' | 'zip'): Buffer
 ```
 
 Get Template Files
@@ -596,7 +596,6 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **templateId** | **string**| The id of the template files to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/docs/api/TemplateApi.md
+++ b/sdks/node/docs/api/TemplateApi.md
@@ -529,7 +529,7 @@ void (empty response body)
 ## `templateFiles()`
 
 ```typescript
-templateFiles(templateId: string, fileType: 'pdf' | 'zip', forceDownload: boolean): Buffer
+templateFiles(templateId: string, fileType: 'pdf' | 'zip', forceDownload: number): Buffer
 ```
 
 Get Template Files
@@ -596,7 +596,7 @@ result.then(response => {
 | ------------- | ------------- | ------------- | ------------- |
 | **templateId** | **string**| The id of the template files to retrieve. | |
 | **fileType** | **'pdf' | 'zip'**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 
@@ -701,7 +701,7 @@ result.then(response => {
 ## `templateFilesAsFileUrl()`
 
 ```typescript
-templateFilesAsFileUrl(templateId: string, forceDownload: boolean): FileResponse
+templateFilesAsFileUrl(templateId: string, forceDownload: number): FileResponse
 ```
 
 Get Template Files as File Url
@@ -763,7 +763,7 @@ result.then(response => {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **templateId** | **string**| The id of the template files to retrieve. | |
-| **forceDownload** | **boolean**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/docs/api/TemplateApi.md
+++ b/sdks/node/docs/api/TemplateApi.md
@@ -762,7 +762,7 @@ result.then(response => {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **templateId** | **string**| The id of the template files to retrieve. | |
-| **forceDownload** | **number**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
+| **forceDownload** | **number**| By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/node/types/api/signatureRequestApi.d.ts
+++ b/sdks/node/types/api/signatureRequestApi.d.ts
@@ -30,9 +30,9 @@ export declare class SignatureRequestApi {
     signatureRequestCancel(signatureRequestId: string, options?: optionsI): Promise<returnTypeI>;
     signatureRequestCreateEmbedded(signatureRequestCreateEmbeddedRequest: SignatureRequestCreateEmbeddedRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestCreateEmbeddedWithTemplate(signatureRequestCreateEmbeddedWithTemplateRequest: SignatureRequestCreateEmbeddedWithTemplateRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
-    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<Buffer>>;
+    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: number, options?: optionsI): Promise<returnTypeT<Buffer>>;
     signatureRequestFilesAsDataUri(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
-    signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<FileResponse>>;
+    signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload?: number, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     signatureRequestGet(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestList(accountId?: string, page?: number, pageSize?: number, query?: string, options?: optionsI): Promise<returnTypeT<SignatureRequestListResponse>>;
     signatureRequestReleaseHold(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;

--- a/sdks/node/types/api/signatureRequestApi.d.ts
+++ b/sdks/node/types/api/signatureRequestApi.d.ts
@@ -30,9 +30,9 @@ export declare class SignatureRequestApi {
     signatureRequestCancel(signatureRequestId: string, options?: optionsI): Promise<returnTypeI>;
     signatureRequestCreateEmbedded(signatureRequestCreateEmbeddedRequest: SignatureRequestCreateEmbeddedRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestCreateEmbeddedWithTemplate(signatureRequestCreateEmbeddedWithTemplateRequest: SignatureRequestCreateEmbeddedWithTemplateRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
-    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", options?: optionsI): Promise<returnTypeT<Buffer>>;
+    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<Buffer>>;
     signatureRequestFilesAsDataUri(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
-    signatureRequestFilesAsFileUrl(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponse>>;
+    signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     signatureRequestGet(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestList(accountId?: string, page?: number, pageSize?: number, query?: string, options?: optionsI): Promise<returnTypeT<SignatureRequestListResponse>>;
     signatureRequestReleaseHold(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;

--- a/sdks/node/types/api/signatureRequestApi.d.ts
+++ b/sdks/node/types/api/signatureRequestApi.d.ts
@@ -30,7 +30,7 @@ export declare class SignatureRequestApi {
     signatureRequestCancel(signatureRequestId: string, options?: optionsI): Promise<returnTypeI>;
     signatureRequestCreateEmbedded(signatureRequestCreateEmbeddedRequest: SignatureRequestCreateEmbeddedRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestCreateEmbeddedWithTemplate(signatureRequestCreateEmbeddedWithTemplateRequest: SignatureRequestCreateEmbeddedWithTemplateRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
-    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: number, options?: optionsI): Promise<returnTypeT<Buffer>>;
+    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", options?: optionsI): Promise<returnTypeT<Buffer>>;
     signatureRequestFilesAsDataUri(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
     signatureRequestFilesAsFileUrl(signatureRequestId: string, forceDownload?: number, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     signatureRequestGet(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;

--- a/sdks/node/types/api/signatureRequestApi.d.ts
+++ b/sdks/node/types/api/signatureRequestApi.d.ts
@@ -30,7 +30,7 @@ export declare class SignatureRequestApi {
     signatureRequestCancel(signatureRequestId: string, options?: optionsI): Promise<returnTypeI>;
     signatureRequestCreateEmbedded(signatureRequestCreateEmbeddedRequest: SignatureRequestCreateEmbeddedRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestCreateEmbeddedWithTemplate(signatureRequestCreateEmbeddedWithTemplateRequest: SignatureRequestCreateEmbeddedWithTemplateRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
-    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", options?: optionsI): Promise<returnTypeT<Buffer>>;
+    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: number, options?: optionsI): Promise<returnTypeT<Buffer>>;
     signatureRequestFilesAsDataUri(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
     signatureRequestFilesAsFileUrl(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     signatureRequestGet(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;

--- a/sdks/node/types/api/signatureRequestApi.d.ts
+++ b/sdks/node/types/api/signatureRequestApi.d.ts
@@ -30,7 +30,7 @@ export declare class SignatureRequestApi {
     signatureRequestCancel(signatureRequestId: string, options?: optionsI): Promise<returnTypeI>;
     signatureRequestCreateEmbedded(signatureRequestCreateEmbeddedRequest: SignatureRequestCreateEmbeddedRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestCreateEmbeddedWithTemplate(signatureRequestCreateEmbeddedWithTemplateRequest: SignatureRequestCreateEmbeddedWithTemplateRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
-    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<Buffer>>;
+    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", options?: optionsI): Promise<returnTypeT<Buffer>>;
     signatureRequestFilesAsDataUri(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
     signatureRequestFilesAsFileUrl(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     signatureRequestGet(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;

--- a/sdks/node/types/api/signatureRequestApi.d.ts
+++ b/sdks/node/types/api/signatureRequestApi.d.ts
@@ -30,7 +30,7 @@ export declare class SignatureRequestApi {
     signatureRequestCancel(signatureRequestId: string, options?: optionsI): Promise<returnTypeI>;
     signatureRequestCreateEmbedded(signatureRequestCreateEmbeddedRequest: SignatureRequestCreateEmbeddedRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
     signatureRequestCreateEmbeddedWithTemplate(signatureRequestCreateEmbeddedWithTemplateRequest: SignatureRequestCreateEmbeddedWithTemplateRequest, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;
-    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: number, options?: optionsI): Promise<returnTypeT<Buffer>>;
+    signatureRequestFiles(signatureRequestId: string, fileType?: "pdf" | "zip", forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<Buffer>>;
     signatureRequestFilesAsDataUri(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
     signatureRequestFilesAsFileUrl(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     signatureRequestGet(signatureRequestId: string, options?: optionsI): Promise<returnTypeT<SignatureRequestGetResponse>>;

--- a/sdks/node/types/api/templateApi.d.ts
+++ b/sdks/node/types/api/templateApi.d.ts
@@ -29,9 +29,9 @@ export declare class TemplateApi {
     templateCreate(templateCreateRequest: TemplateCreateRequest, options?: optionsI): Promise<returnTypeT<TemplateCreateResponse>>;
     templateCreateEmbeddedDraft(templateCreateEmbeddedDraftRequest: TemplateCreateEmbeddedDraftRequest, options?: optionsI): Promise<returnTypeT<TemplateCreateEmbeddedDraftResponse>>;
     templateDelete(templateId: string, options?: optionsI): Promise<returnTypeI>;
-    templateFiles(templateId: string, fileType?: "pdf" | "zip", options?: optionsI): Promise<returnTypeT<Buffer>>;
+    templateFiles(templateId: string, fileType?: "pdf" | "zip", forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<Buffer>>;
     templateFilesAsDataUri(templateId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
-    templateFilesAsFileUrl(templateId: string, options?: optionsI): Promise<returnTypeT<FileResponse>>;
+    templateFilesAsFileUrl(templateId: string, forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     templateGet(templateId: string, options?: optionsI): Promise<returnTypeT<TemplateGetResponse>>;
     templateList(accountId?: string, page?: number, pageSize?: number, query?: string, options?: optionsI): Promise<returnTypeT<TemplateListResponse>>;
     templateRemoveUser(templateId: string, templateRemoveUserRequest: TemplateRemoveUserRequest, options?: optionsI): Promise<returnTypeT<TemplateGetResponse>>;

--- a/sdks/node/types/api/templateApi.d.ts
+++ b/sdks/node/types/api/templateApi.d.ts
@@ -29,9 +29,9 @@ export declare class TemplateApi {
     templateCreate(templateCreateRequest: TemplateCreateRequest, options?: optionsI): Promise<returnTypeT<TemplateCreateResponse>>;
     templateCreateEmbeddedDraft(templateCreateEmbeddedDraftRequest: TemplateCreateEmbeddedDraftRequest, options?: optionsI): Promise<returnTypeT<TemplateCreateEmbeddedDraftResponse>>;
     templateDelete(templateId: string, options?: optionsI): Promise<returnTypeI>;
-    templateFiles(templateId: string, fileType?: "pdf" | "zip", forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<Buffer>>;
+    templateFiles(templateId: string, fileType?: "pdf" | "zip", forceDownload?: number, options?: optionsI): Promise<returnTypeT<Buffer>>;
     templateFilesAsDataUri(templateId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
-    templateFilesAsFileUrl(templateId: string, forceDownload?: boolean, options?: optionsI): Promise<returnTypeT<FileResponse>>;
+    templateFilesAsFileUrl(templateId: string, forceDownload?: number, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     templateGet(templateId: string, options?: optionsI): Promise<returnTypeT<TemplateGetResponse>>;
     templateList(accountId?: string, page?: number, pageSize?: number, query?: string, options?: optionsI): Promise<returnTypeT<TemplateListResponse>>;
     templateRemoveUser(templateId: string, templateRemoveUserRequest: TemplateRemoveUserRequest, options?: optionsI): Promise<returnTypeT<TemplateGetResponse>>;

--- a/sdks/node/types/api/templateApi.d.ts
+++ b/sdks/node/types/api/templateApi.d.ts
@@ -29,7 +29,7 @@ export declare class TemplateApi {
     templateCreate(templateCreateRequest: TemplateCreateRequest, options?: optionsI): Promise<returnTypeT<TemplateCreateResponse>>;
     templateCreateEmbeddedDraft(templateCreateEmbeddedDraftRequest: TemplateCreateEmbeddedDraftRequest, options?: optionsI): Promise<returnTypeT<TemplateCreateEmbeddedDraftResponse>>;
     templateDelete(templateId: string, options?: optionsI): Promise<returnTypeI>;
-    templateFiles(templateId: string, fileType?: "pdf" | "zip", forceDownload?: number, options?: optionsI): Promise<returnTypeT<Buffer>>;
+    templateFiles(templateId: string, fileType?: "pdf" | "zip", options?: optionsI): Promise<returnTypeT<Buffer>>;
     templateFilesAsDataUri(templateId: string, options?: optionsI): Promise<returnTypeT<FileResponseDataUri>>;
     templateFilesAsFileUrl(templateId: string, forceDownload?: number, options?: optionsI): Promise<returnTypeT<FileResponse>>;
     templateGet(templateId: string, options?: optionsI): Promise<returnTypeT<TemplateGetResponse>>;

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -461,7 +461,7 @@ try {
 ## `signatureRequestFiles()`
 
 ```php
-signatureRequestFiles($signature_request_id, $file_type, $force_download): \SplFileObject
+signatureRequestFiles($signature_request_id, $file_type): \SplFileObject
 ```
 
 Download Files
@@ -505,7 +505,6 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -505,7 +505,7 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **force_download** | **int**| If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1] |
+| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -461,7 +461,7 @@ try {
 ## `signatureRequestFiles()`
 
 ```php
-signatureRequestFiles($signature_request_id, $file_type, $force_download): \SplFileObject
+signatureRequestFiles($signature_request_id, $file_type): \SplFileObject
 ```
 
 Download Files
@@ -505,7 +505,6 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -461,7 +461,7 @@ try {
 ## `signatureRequestFiles()`
 
 ```php
-signatureRequestFiles($signature_request_id, $file_type): \SplFileObject
+signatureRequestFiles($signature_request_id, $file_type, $force_download): \SplFileObject
 ```
 
 Download Files
@@ -505,6 +505,7 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
+| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 
@@ -589,7 +590,7 @@ try {
 ## `signatureRequestFilesAsFileUrl()`
 
 ```php
-signatureRequestFilesAsFileUrl($signature_request_id): \Dropbox\Sign\Model\FileResponse
+signatureRequestFilesAsFileUrl($signature_request_id, $force_download): \Dropbox\Sign\Model\FileResponse
 ```
 
 Download Files as File Url
@@ -631,6 +632,7 @@ try {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
+| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -631,7 +631,7 @@ try {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
-| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
+| **force_download** | **int**| By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -505,7 +505,7 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
-| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 
@@ -632,7 +632,7 @@ try {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
-| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -461,7 +461,7 @@ try {
 ## `signatureRequestFiles()`
 
 ```php
-signatureRequestFiles($signature_request_id, $file_type): \SplFileObject
+signatureRequestFiles($signature_request_id, $file_type, $force_download): \SplFileObject
 ```
 
 Download Files
@@ -505,6 +505,7 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **signature_request_id** | **string**| The id of the SignatureRequest to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] [default to &#39;pdf&#39;] |
+| **force_download** | **int**| If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/TemplateApi.md
+++ b/sdks/php/docs/Api/TemplateApi.md
@@ -333,7 +333,7 @@ void (empty response body)
 ## `templateFiles()`
 
 ```php
-templateFiles($template_id, $file_type): \SplFileObject
+templateFiles($template_id, $file_type, $force_download): \SplFileObject
 ```
 
 Get Template Files
@@ -377,6 +377,7 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **template_id** | **string**| The id of the template files to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
+| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 
@@ -461,7 +462,7 @@ try {
 ## `templateFilesAsFileUrl()`
 
 ```php
-templateFilesAsFileUrl($template_id): \Dropbox\Sign\Model\FileResponse
+templateFilesAsFileUrl($template_id, $force_download): \Dropbox\Sign\Model\FileResponse
 ```
 
 Get Template Files as File Url
@@ -503,6 +504,7 @@ try {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **template_id** | **string**| The id of the template files to retrieve. | |
+| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/TemplateApi.md
+++ b/sdks/php/docs/Api/TemplateApi.md
@@ -333,7 +333,7 @@ void (empty response body)
 ## `templateFiles()`
 
 ```php
-templateFiles($template_id, $file_type, $force_download): \SplFileObject
+templateFiles($template_id, $file_type): \SplFileObject
 ```
 
 Get Template Files
@@ -377,7 +377,6 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **template_id** | **string**| The id of the template files to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/TemplateApi.md
+++ b/sdks/php/docs/Api/TemplateApi.md
@@ -503,7 +503,7 @@ try {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **template_id** | **string**| The id of the template files to retrieve. | |
-| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
+| **force_download** | **int**| By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/docs/Api/TemplateApi.md
+++ b/sdks/php/docs/Api/TemplateApi.md
@@ -377,7 +377,7 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **template_id** | **string**| The id of the template files to retrieve. | |
 | **file_type** | **string**| Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 
@@ -504,7 +504,7 @@ try {
 |Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
 | **template_id** | **string**| The id of the template files to retrieve. | |
-| **force_download** | **bool**| By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional] [default to true] |
+| **force_download** | **int**| By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional] [default to 1] |
 
 ### Return type
 

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -1655,14 +1655,15 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
-        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type);
+        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type, $force_download);
 
         return $response;
     }
@@ -1674,14 +1675,15 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1797,13 +1799,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
-        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type)
+        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type, $force_download)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1818,14 +1821,15 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         $returnType = '\SplFileObject';
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1865,11 +1869,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {
@@ -1894,6 +1899,16 @@ class SignatureRequestApi
                 }
             } else {
                 $queryParams['file_type'] = $file_type;
+            }
+        }
+        // query params
+        if ($force_download !== null) {
+            if ('form' === 'form' && is_array($force_download)) {
+                foreach ($force_download as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            } else {
+                $queryParams['force_download'] = $force_download;
             }
         }
 

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -1655,14 +1655,15 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
-        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type);
+        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type, $force_download);
 
         return $response;
     }
@@ -1674,14 +1675,15 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1797,13 +1799,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
-        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type)
+        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type, $force_download)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1818,14 +1821,15 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         $returnType = '\SplFileObject';
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1865,11 +1869,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf')
+    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {
@@ -1894,6 +1899,16 @@ class SignatureRequestApi
                 }
             } else {
                 $queryParams['file_type'] = $file_type;
+            }
+        }
+        // query params
+        if ($force_download !== null) {
+            if ('form' === 'form' && is_array($force_download)) {
+                foreach ($force_download as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            } else {
+                $queryParams['force_download'] = $force_download;
             }
         }
 
@@ -2298,14 +2313,15 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return Model\FileResponse
      */
-    public function signatureRequestFilesAsFileUrl(string $signature_request_id)
+    public function signatureRequestFilesAsFileUrl(string $signature_request_id, bool $force_download = true)
     {
-        list($response) = $this->signatureRequestFilesAsFileUrlWithHttpInfo($signature_request_id);
+        list($response) = $this->signatureRequestFilesAsFileUrlWithHttpInfo($signature_request_id, $force_download);
 
         return $response;
     }
@@ -2316,14 +2332,15 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of Model\FileResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesAsFileUrlWithHttpInfo(string $signature_request_id)
+    public function signatureRequestFilesAsFileUrlWithHttpInfo(string $signature_request_id, bool $force_download = true)
     {
-        $request = $this->signatureRequestFilesAsFileUrlRequest($signature_request_id);
+        $request = $this->signatureRequestFilesAsFileUrlRequest($signature_request_id, $force_download);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2438,13 +2455,14 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsFileUrlAsync(string $signature_request_id)
+    public function signatureRequestFilesAsFileUrlAsync(string $signature_request_id, bool $force_download = true)
     {
-        return $this->signatureRequestFilesAsFileUrlAsyncWithHttpInfo($signature_request_id)
+        return $this->signatureRequestFilesAsFileUrlAsyncWithHttpInfo($signature_request_id, $force_download)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2458,14 +2476,15 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsFileUrlAsyncWithHttpInfo(string $signature_request_id)
+    public function signatureRequestFilesAsFileUrlAsyncWithHttpInfo(string $signature_request_id, bool $force_download = true)
     {
         $returnType = '\Dropbox\Sign\Model\FileResponse';
-        $request = $this->signatureRequestFilesAsFileUrlRequest($signature_request_id);
+        $request = $this->signatureRequestFilesAsFileUrlRequest($signature_request_id, $force_download);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2504,11 +2523,12 @@ class SignatureRequestApi
      * Create request for operation 'signatureRequestFilesAsFileUrl'
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesAsFileUrlRequest(string $signature_request_id)
+    public function signatureRequestFilesAsFileUrlRequest(string $signature_request_id, bool $force_download = true)
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {
@@ -2524,6 +2544,17 @@ class SignatureRequestApi
 
         $formParams = [];
         $multipart = false;
+
+        // query params
+        if ($force_download !== null) {
+            if ('form' === 'form' && is_array($force_download)) {
+                foreach ($force_download as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            } else {
+                $queryParams['force_download'] = $force_download;
+            }
+        }
 
         // path params
         if ($signature_request_id !== null) {

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -1655,13 +1655,13 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type, $force_download);
 
@@ -1675,13 +1675,13 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
 
@@ -1799,12 +1799,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type, $force_download)
             ->then(
@@ -1821,12 +1821,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         $returnType = '\SplFileObject';
         $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
@@ -1869,12 +1869,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to 1)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -1655,15 +1655,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf')
     {
-        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type, $force_download);
+        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type);
 
         return $response;
     }
@@ -1675,15 +1674,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
     {
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1799,14 +1797,13 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf')
     {
-        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type, $force_download)
+        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1821,15 +1818,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
     {
         $returnType = '\SplFileObject';
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1869,12 +1865,11 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
+    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf')
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {
@@ -1899,16 +1894,6 @@ class SignatureRequestApi
                 }
             } else {
                 $queryParams['file_type'] = $file_type;
-            }
-        }
-        // query params
-        if ($force_download !== null) {
-            if ('form' === 'form' && is_array($force_download)) {
-                foreach ($force_download as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            } else {
-                $queryParams['force_download'] = $force_download;
             }
         }
 

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -1655,13 +1655,13 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type, $force_download);
 
@@ -1675,13 +1675,13 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
 
@@ -1799,12 +1799,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type, $force_download)
             ->then(
@@ -1821,12 +1821,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         $returnType = '\SplFileObject';
         $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
@@ -1869,12 +1869,12 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', int $force_download = 1)
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {
@@ -2313,13 +2313,13 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return Model\FileResponse
      */
-    public function signatureRequestFilesAsFileUrl(string $signature_request_id, bool $force_download = true)
+    public function signatureRequestFilesAsFileUrl(string $signature_request_id, int $force_download = 1)
     {
         list($response) = $this->signatureRequestFilesAsFileUrlWithHttpInfo($signature_request_id, $force_download);
 
@@ -2332,13 +2332,13 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of Model\FileResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesAsFileUrlWithHttpInfo(string $signature_request_id, bool $force_download = true)
+    public function signatureRequestFilesAsFileUrlWithHttpInfo(string $signature_request_id, int $force_download = 1)
     {
         $request = $this->signatureRequestFilesAsFileUrlRequest($signature_request_id, $force_download);
 
@@ -2455,12 +2455,12 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsFileUrlAsync(string $signature_request_id, bool $force_download = true)
+    public function signatureRequestFilesAsFileUrlAsync(string $signature_request_id, int $force_download = 1)
     {
         return $this->signatureRequestFilesAsFileUrlAsyncWithHttpInfo($signature_request_id, $force_download)
             ->then(
@@ -2476,12 +2476,12 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsFileUrlAsyncWithHttpInfo(string $signature_request_id, bool $force_download = true)
+    public function signatureRequestFilesAsFileUrlAsyncWithHttpInfo(string $signature_request_id, int $force_download = 1)
     {
         $returnType = '\Dropbox\Sign\Model\FileResponse';
         $request = $this->signatureRequestFilesAsFileUrlRequest($signature_request_id, $force_download);
@@ -2523,12 +2523,12 @@ class SignatureRequestApi
      * Create request for operation 'signatureRequestFilesAsFileUrl'
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesAsFileUrlRequest(string $signature_request_id, bool $force_download = true)
+    public function signatureRequestFilesAsFileUrlRequest(string $signature_request_id, int $force_download = 1)
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -2298,7 +2298,7 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
@@ -2317,7 +2317,7 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
@@ -2440,7 +2440,7 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
@@ -2461,7 +2461,7 @@ class SignatureRequestApi
      * Download Files as File Url
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
@@ -2508,7 +2508,7 @@ class SignatureRequestApi
      * Create request for operation 'signatureRequestFilesAsFileUrl'
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request

--- a/sdks/php/src/Api/SignatureRequestApi.php
+++ b/sdks/php/src/Api/SignatureRequestApi.php
@@ -1655,15 +1655,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFiles(string $signature_request_id, string $file_type = 'pdf')
     {
-        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type, $force_download);
+        list($response) = $this->signatureRequestFilesWithHttpInfo($signature_request_id, $file_type);
 
         return $response;
     }
@@ -1675,15 +1674,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
     {
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1799,14 +1797,13 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesAsync(string $signature_request_id, string $file_type = 'pdf')
     {
-        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type, $force_download)
+        return $this->signatureRequestFilesAsyncWithHttpInfo($signature_request_id, $file_type)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1821,15 +1818,14 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesAsyncWithHttpInfo(string $signature_request_id, string $file_type = 'pdf')
     {
         $returnType = '\SplFileObject';
-        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type, $force_download);
+        $request = $this->signatureRequestFilesRequest($signature_request_id, $file_type);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1869,12 +1865,11 @@ class SignatureRequestApi
      *
      * @param string $signature_request_id The id of the SignatureRequest to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional, default to 'pdf')
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf', bool $force_download = true)
+    public function signatureRequestFilesRequest(string $signature_request_id, string $file_type = 'pdf')
     {
         // verify the required parameter 'signature_request_id' is set
         if ($signature_request_id === null || (is_array($signature_request_id) && count($signature_request_id) === 0)) {
@@ -1899,16 +1894,6 @@ class SignatureRequestApi
                 }
             } else {
                 $queryParams['file_type'] = $file_type;
-            }
-        }
-        // query params
-        if ($force_download !== null) {
-            if ('form' === 'form' && is_array($force_download)) {
-                foreach ($force_download as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            } else {
-                $queryParams['force_download'] = $force_download;
             }
         }
 

--- a/sdks/php/src/Api/TemplateApi.php
+++ b/sdks/php/src/Api/TemplateApi.php
@@ -1361,14 +1361,15 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function templateFiles(string $template_id, string $file_type = null)
+    public function templateFiles(string $template_id, string $file_type = null, bool $force_download = true)
     {
-        list($response) = $this->templateFilesWithHttpInfo($template_id, $file_type);
+        list($response) = $this->templateFilesWithHttpInfo($template_id, $file_type, $force_download);
 
         return $response;
     }
@@ -1380,14 +1381,15 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function templateFilesWithHttpInfo(string $template_id, string $file_type = null)
+    public function templateFilesWithHttpInfo(string $template_id, string $file_type = null, bool $force_download = true)
     {
-        $request = $this->templateFilesRequest($template_id, $file_type);
+        $request = $this->templateFilesRequest($template_id, $file_type, $force_download);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1503,13 +1505,14 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsync(string $template_id, string $file_type = null)
+    public function templateFilesAsync(string $template_id, string $file_type = null, bool $force_download = true)
     {
-        return $this->templateFilesAsyncWithHttpInfo($template_id, $file_type)
+        return $this->templateFilesAsyncWithHttpInfo($template_id, $file_type, $force_download)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1524,14 +1527,15 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsyncWithHttpInfo(string $template_id, string $file_type = null)
+    public function templateFilesAsyncWithHttpInfo(string $template_id, string $file_type = null, bool $force_download = true)
     {
         $returnType = '\SplFileObject';
-        $request = $this->templateFilesRequest($template_id, $file_type);
+        $request = $this->templateFilesRequest($template_id, $file_type, $force_download);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1571,11 +1575,12 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function templateFilesRequest(string $template_id, string $file_type = null)
+    public function templateFilesRequest(string $template_id, string $file_type = null, bool $force_download = true)
     {
         // verify the required parameter 'template_id' is set
         if ($template_id === null || (is_array($template_id) && count($template_id) === 0)) {
@@ -1600,6 +1605,16 @@ class TemplateApi
                 }
             } else {
                 $queryParams['file_type'] = $file_type;
+            }
+        }
+        // query params
+        if ($force_download !== null) {
+            if ('form' === 'form' && is_array($force_download)) {
+                foreach ($force_download as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            } else {
+                $queryParams['force_download'] = $force_download;
             }
         }
 
@@ -2004,14 +2019,15 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return Model\FileResponse
      */
-    public function templateFilesAsFileUrl(string $template_id)
+    public function templateFilesAsFileUrl(string $template_id, bool $force_download = true)
     {
-        list($response) = $this->templateFilesAsFileUrlWithHttpInfo($template_id);
+        list($response) = $this->templateFilesAsFileUrlWithHttpInfo($template_id, $force_download);
 
         return $response;
     }
@@ -2022,14 +2038,15 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of Model\FileResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function templateFilesAsFileUrlWithHttpInfo(string $template_id)
+    public function templateFilesAsFileUrlWithHttpInfo(string $template_id, bool $force_download = true)
     {
-        $request = $this->templateFilesAsFileUrlRequest($template_id);
+        $request = $this->templateFilesAsFileUrlRequest($template_id, $force_download);
 
         try {
             $options = $this->createHttpClientOption();
@@ -2144,13 +2161,14 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsFileUrlAsync(string $template_id)
+    public function templateFilesAsFileUrlAsync(string $template_id, bool $force_download = true)
     {
-        return $this->templateFilesAsFileUrlAsyncWithHttpInfo($template_id)
+        return $this->templateFilesAsFileUrlAsyncWithHttpInfo($template_id, $force_download)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -2164,14 +2182,15 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsFileUrlAsyncWithHttpInfo(string $template_id)
+    public function templateFilesAsFileUrlAsyncWithHttpInfo(string $template_id, bool $force_download = true)
     {
         $returnType = '\Dropbox\Sign\Model\FileResponse';
-        $request = $this->templateFilesAsFileUrlRequest($template_id);
+        $request = $this->templateFilesAsFileUrlRequest($template_id, $force_download);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -2210,11 +2229,12 @@ class TemplateApi
      * Create request for operation 'templateFilesAsFileUrl'
      *
      * @param string $template_id The id of the template files to retrieve. (required)
+     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function templateFilesAsFileUrlRequest(string $template_id)
+    public function templateFilesAsFileUrlRequest(string $template_id, bool $force_download = true)
     {
         // verify the required parameter 'template_id' is set
         if ($template_id === null || (is_array($template_id) && count($template_id) === 0)) {
@@ -2230,6 +2250,17 @@ class TemplateApi
 
         $formParams = [];
         $multipart = false;
+
+        // query params
+        if ($force_download !== null) {
+            if ('form' === 'form' && is_array($force_download)) {
+                foreach ($force_download as $key => $value) {
+                    $queryParams[$key] = $value;
+                }
+            } else {
+                $queryParams['force_download'] = $force_download;
+            }
+        }
 
         // path params
         if ($template_id !== null) {

--- a/sdks/php/src/Api/TemplateApi.php
+++ b/sdks/php/src/Api/TemplateApi.php
@@ -1361,15 +1361,14 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function templateFiles(string $template_id, string $file_type = null, int $force_download = 1)
+    public function templateFiles(string $template_id, string $file_type = null)
     {
-        list($response) = $this->templateFilesWithHttpInfo($template_id, $file_type, $force_download);
+        list($response) = $this->templateFilesWithHttpInfo($template_id, $file_type);
 
         return $response;
     }
@@ -1381,15 +1380,14 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function templateFilesWithHttpInfo(string $template_id, string $file_type = null, int $force_download = 1)
+    public function templateFilesWithHttpInfo(string $template_id, string $file_type = null)
     {
-        $request = $this->templateFilesRequest($template_id, $file_type, $force_download);
+        $request = $this->templateFilesRequest($template_id, $file_type);
 
         try {
             $options = $this->createHttpClientOption();
@@ -1505,14 +1503,13 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsync(string $template_id, string $file_type = null, int $force_download = 1)
+    public function templateFilesAsync(string $template_id, string $file_type = null)
     {
-        return $this->templateFilesAsyncWithHttpInfo($template_id, $file_type, $force_download)
+        return $this->templateFilesAsyncWithHttpInfo($template_id, $file_type)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -1527,15 +1524,14 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsyncWithHttpInfo(string $template_id, string $file_type = null, int $force_download = 1)
+    public function templateFilesAsyncWithHttpInfo(string $template_id, string $file_type = null)
     {
         $returnType = '\SplFileObject';
-        $request = $this->templateFilesRequest($template_id, $file_type, $force_download);
+        $request = $this->templateFilesRequest($template_id, $file_type);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -1575,12 +1571,11 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function templateFilesRequest(string $template_id, string $file_type = null, int $force_download = 1)
+    public function templateFilesRequest(string $template_id, string $file_type = null)
     {
         // verify the required parameter 'template_id' is set
         if ($template_id === null || (is_array($template_id) && count($template_id) === 0)) {
@@ -1605,16 +1600,6 @@ class TemplateApi
                 }
             } else {
                 $queryParams['file_type'] = $file_type;
-            }
-        }
-        // query params
-        if ($force_download !== null) {
-            if ('form' === 'form' && is_array($force_download)) {
-                foreach ($force_download as $key => $value) {
-                    $queryParams[$key] = $value;
-                }
-            } else {
-                $queryParams['force_download'] = $force_download;
             }
         }
 

--- a/sdks/php/src/Api/TemplateApi.php
+++ b/sdks/php/src/Api/TemplateApi.php
@@ -1361,13 +1361,13 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return SplFileObject
      */
-    public function templateFiles(string $template_id, string $file_type = null, bool $force_download = true)
+    public function templateFiles(string $template_id, string $file_type = null, int $force_download = 1)
     {
         list($response) = $this->templateFilesWithHttpInfo($template_id, $file_type, $force_download);
 
@@ -1381,13 +1381,13 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of \SplFileObject|\Dropbox\Sign\Model\ErrorResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function templateFilesWithHttpInfo(string $template_id, string $file_type = null, bool $force_download = true)
+    public function templateFilesWithHttpInfo(string $template_id, string $file_type = null, int $force_download = 1)
     {
         $request = $this->templateFilesRequest($template_id, $file_type, $force_download);
 
@@ -1505,12 +1505,12 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsync(string $template_id, string $file_type = null, bool $force_download = true)
+    public function templateFilesAsync(string $template_id, string $file_type = null, int $force_download = 1)
     {
         return $this->templateFilesAsyncWithHttpInfo($template_id, $file_type, $force_download)
             ->then(
@@ -1527,12 +1527,12 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsyncWithHttpInfo(string $template_id, string $file_type = null, bool $force_download = true)
+    public function templateFilesAsyncWithHttpInfo(string $template_id, string $file_type = null, int $force_download = 1)
     {
         $returnType = '\SplFileObject';
         $request = $this->templateFilesRequest($template_id, $file_type, $force_download);
@@ -1575,12 +1575,12 @@ class TemplateApi
      *
      * @param string $template_id The id of the template files to retrieve. (required)
      * @param string $file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (optional)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function templateFilesRequest(string $template_id, string $file_type = null, bool $force_download = true)
+    public function templateFilesRequest(string $template_id, string $file_type = null, int $force_download = 1)
     {
         // verify the required parameter 'template_id' is set
         if ($template_id === null || (is_array($template_id) && count($template_id) === 0)) {
@@ -2019,13 +2019,13 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return Model\FileResponse
      */
-    public function templateFilesAsFileUrl(string $template_id, bool $force_download = true)
+    public function templateFilesAsFileUrl(string $template_id, int $force_download = 1)
     {
         list($response) = $this->templateFilesAsFileUrlWithHttpInfo($template_id, $force_download);
 
@@ -2038,13 +2038,13 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of Model\FileResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function templateFilesAsFileUrlWithHttpInfo(string $template_id, bool $force_download = true)
+    public function templateFilesAsFileUrlWithHttpInfo(string $template_id, int $force_download = 1)
     {
         $request = $this->templateFilesAsFileUrlRequest($template_id, $force_download);
 
@@ -2161,12 +2161,12 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsFileUrlAsync(string $template_id, bool $force_download = true)
+    public function templateFilesAsFileUrlAsync(string $template_id, int $force_download = 1)
     {
         return $this->templateFilesAsFileUrlAsyncWithHttpInfo($template_id, $force_download)
             ->then(
@@ -2182,12 +2182,12 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
      */
-    public function templateFilesAsFileUrlAsyncWithHttpInfo(string $template_id, bool $force_download = true)
+    public function templateFilesAsFileUrlAsyncWithHttpInfo(string $template_id, int $force_download = 1)
     {
         $returnType = '\Dropbox\Sign\Model\FileResponse';
         $request = $this->templateFilesAsFileUrlRequest($template_id, $force_download);
@@ -2229,12 +2229,12 @@ class TemplateApi
      * Create request for operation 'templateFilesAsFileUrl'
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param bool $force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (optional, default to true)
+     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request
      */
-    public function templateFilesAsFileUrlRequest(string $template_id, bool $force_download = true)
+    public function templateFilesAsFileUrlRequest(string $template_id, int $force_download = 1)
     {
         // verify the required parameter 'template_id' is set
         if ($template_id === null || (is_array($template_id) && count($template_id) === 0)) {

--- a/sdks/php/src/Api/TemplateApi.php
+++ b/sdks/php/src/Api/TemplateApi.php
@@ -2004,7 +2004,7 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
@@ -2023,7 +2023,7 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
@@ -2146,7 +2146,7 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
@@ -2167,7 +2167,7 @@ class TemplateApi
      * Get Template Files as File Url
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Promise\PromiseInterface
@@ -2214,7 +2214,7 @@ class TemplateApi
      * Create request for operation 'templateFilesAsFileUrl'
      *
      * @param string $template_id The id of the template files to retrieve. (required)
-     * @param int $force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
+     * @param int $force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (optional, default to 1)
      *
      * @throws InvalidArgumentException
      * @return Psr7\Request

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -554,7 +554,7 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &quot;pdf&quot;] |
-| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
+| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 
@@ -693,7 +693,7 @@ with ApiClient(configuration) as api_client:
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
-| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
+| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -554,7 +554,6 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &quot;pdf&quot;] |
-| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to True] |
 
 ### Return type
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -554,7 +554,7 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &quot;pdf&quot;] |
-| `force_download` | **int** | If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to 1] |
+| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to True] |
 
 ### Return type
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -692,7 +692,7 @@ with ApiClient(configuration) as api_client:
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
-| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
+| `force_download` | **int** | By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -554,7 +554,6 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &quot;pdf&quot;] |
-| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -554,6 +554,7 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &quot;pdf&quot;] |
+| `force_download` | **int** | If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -554,6 +554,7 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &quot;pdf&quot;] |
+| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
 
 ### Return type
 
@@ -692,6 +693,7 @@ with ApiClient(configuration) as api_client:
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **str** | The id of the SignatureRequest to retrieve. |  |
+| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
 
 ### Return type
 

--- a/sdks/python/docs/TemplateApi.md
+++ b/sdks/python/docs/TemplateApi.md
@@ -411,6 +411,7 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **str** | The id of the template files to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
+| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
 
 ### Return type
 
@@ -549,6 +550,7 @@ with ApiClient(configuration) as api_client:
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **str** | The id of the template files to retrieve. |  |
+| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
 
 ### Return type
 

--- a/sdks/python/docs/TemplateApi.md
+++ b/sdks/python/docs/TemplateApi.md
@@ -411,7 +411,7 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **str** | The id of the template files to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
+| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 
@@ -550,7 +550,7 @@ with ApiClient(configuration) as api_client:
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **str** | The id of the template files to retrieve. |  |
-| `force_download` | **bool** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to True] |
+| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/docs/TemplateApi.md
+++ b/sdks/python/docs/TemplateApi.md
@@ -411,7 +411,6 @@ with ApiClient(configuration) as api_client:
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **str** | The id of the template files to retrieve. |  |
 | `file_type` | **str** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/docs/TemplateApi.md
+++ b/sdks/python/docs/TemplateApi.md
@@ -549,7 +549,7 @@ with ApiClient(configuration) as api_client:
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **str** | The id of the template files to retrieve. |  |
-| `force_download` | **int** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
+| `force_download` | **int** | By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -333,7 +333,6 @@ class SignatureRequestApi(object):
                 'all': [
                     'signature_request_id',
                     'file_type',
-                    'force_download',
                 ],
                 'required': [
                     'signature_request_id',
@@ -361,18 +360,14 @@ class SignatureRequestApi(object):
                         (str,),
                     'file_type':
                         (str,),
-                    'force_download':
-                        (bool,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
                     'file_type': 'file_type',
-                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'signature_request_id': 'path',
                     'file_type': 'query',
-                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -1435,7 +1430,6 @@ class SignatureRequestApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional] if omitted the server will use the default value of "pdf"
-            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.. [optional] if omitted the server will use the default value of True
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -333,7 +333,6 @@ class SignatureRequestApi(object):
                 'all': [
                     'signature_request_id',
                     'file_type',
-                    'force_download',
                 ],
                 'required': [
                     'signature_request_id',
@@ -361,18 +360,14 @@ class SignatureRequestApi(object):
                         (str,),
                     'file_type':
                         (str,),
-                    'force_download':
-                        (int,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
                     'file_type': 'file_type',
-                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'signature_request_id': 'path',
                     'file_type': 'query',
-                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -1440,7 +1435,6 @@ class SignatureRequestApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional] if omitted the server will use the default value of "pdf"
-            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -362,7 +362,7 @@ class SignatureRequestApi(object):
                     'file_type':
                         (str,),
                     'force_download':
-                        (bool,),
+                        (int,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
@@ -475,7 +475,7 @@ class SignatureRequestApi(object):
                     'signature_request_id':
                         (str,),
                     'force_download':
-                        (bool,),
+                        (int,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
@@ -1440,7 +1440,7 @@ class SignatureRequestApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional] if omitted the server will use the default value of "pdf"
-            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
+            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -1641,7 +1641,7 @@ class SignatureRequestApi(object):
             signature_request_id (str): The id of the SignatureRequest to retrieve.
 
         Keyword Args:
-            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
+            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -333,6 +333,7 @@ class SignatureRequestApi(object):
                 'all': [
                     'signature_request_id',
                     'file_type',
+                    'force_download',
                 ],
                 'required': [
                     'signature_request_id',
@@ -360,14 +361,18 @@ class SignatureRequestApi(object):
                         (str,),
                     'file_type':
                         (str,),
+                    'force_download':
+                        (bool,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
                     'file_type': 'file_type',
+                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'signature_request_id': 'path',
                     'file_type': 'query',
+                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -449,6 +454,7 @@ class SignatureRequestApi(object):
             params_map={
                 'all': [
                     'signature_request_id',
+                    'force_download',
                 ],
                 'required': [
                     'signature_request_id',
@@ -468,12 +474,16 @@ class SignatureRequestApi(object):
                 'openapi_types': {
                     'signature_request_id':
                         (str,),
+                    'force_download':
+                        (bool,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
+                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'signature_request_id': 'path',
+                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -1430,6 +1440,7 @@ class SignatureRequestApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional] if omitted the server will use the default value of "pdf"
+            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -1630,6 +1641,7 @@ class SignatureRequestApi(object):
             signature_request_id (str): The id of the SignatureRequest to retrieve.
 
         Keyword Args:
+            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -362,7 +362,7 @@ class SignatureRequestApi(object):
                     'file_type':
                         (str,),
                     'force_download':
-                        (int,),
+                        (bool,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
@@ -1435,7 +1435,7 @@ class SignatureRequestApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional] if omitted the server will use the default value of "pdf"
-            force_download (int): If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.. [optional] if omitted the server will use the default value of 1
+            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.. [optional] if omitted the server will use the default value of True
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -1635,7 +1635,7 @@ class SignatureRequestApi(object):
             signature_request_id (str): The id of the SignatureRequest to retrieve.
 
         Keyword Args:
-            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
+            force_download (int): By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -333,6 +333,7 @@ class SignatureRequestApi(object):
                 'all': [
                     'signature_request_id',
                     'file_type',
+                    'force_download',
                 ],
                 'required': [
                     'signature_request_id',
@@ -360,14 +361,18 @@ class SignatureRequestApi(object):
                         (str,),
                     'file_type':
                         (str,),
+                    'force_download':
+                        (int,),
                 },
                 'attribute_map': {
                     'signature_request_id': 'signature_request_id',
                     'file_type': 'file_type',
+                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'signature_request_id': 'path',
                     'file_type': 'query',
+                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -1430,6 +1435,7 @@ class SignatureRequestApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional] if omitted the server will use the default value of "pdf"
+            force_download (int): If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/template_api.py
+++ b/sdks/python/dropbox_sign/api/template_api.py
@@ -313,7 +313,7 @@ class TemplateApi(object):
                     'file_type':
                         (str,),
                     'force_download':
-                        (bool,),
+                        (int,),
                 },
                 'attribute_map': {
                     'template_id': 'template_id',
@@ -426,7 +426,7 @@ class TemplateApi(object):
                     'template_id':
                         (str,),
                     'force_download':
-                        (bool,),
+                        (int,),
                 },
                 'attribute_map': {
                     'template_id': 'template_id',
@@ -1091,7 +1091,7 @@ class TemplateApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional]
-            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
+            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -1292,7 +1292,7 @@ class TemplateApi(object):
             template_id (str): The id of the template files to retrieve.
 
         Keyword Args:
-            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
+            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/template_api.py
+++ b/sdks/python/dropbox_sign/api/template_api.py
@@ -284,7 +284,6 @@ class TemplateApi(object):
                 'all': [
                     'template_id',
                     'file_type',
-                    'force_download',
                 ],
                 'required': [
                     'template_id',
@@ -312,18 +311,14 @@ class TemplateApi(object):
                         (str,),
                     'file_type':
                         (str,),
-                    'force_download':
-                        (int,),
                 },
                 'attribute_map': {
                     'template_id': 'template_id',
                     'file_type': 'file_type',
-                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'template_id': 'path',
                     'file_type': 'query',
-                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -1091,7 +1086,6 @@ class TemplateApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional]
-            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/template_api.py
+++ b/sdks/python/dropbox_sign/api/template_api.py
@@ -284,6 +284,7 @@ class TemplateApi(object):
                 'all': [
                     'template_id',
                     'file_type',
+                    'force_download',
                 ],
                 'required': [
                     'template_id',
@@ -311,14 +312,18 @@ class TemplateApi(object):
                         (str,),
                     'file_type':
                         (str,),
+                    'force_download':
+                        (bool,),
                 },
                 'attribute_map': {
                     'template_id': 'template_id',
                     'file_type': 'file_type',
+                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'template_id': 'path',
                     'file_type': 'query',
+                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -400,6 +405,7 @@ class TemplateApi(object):
             params_map={
                 'all': [
                     'template_id',
+                    'force_download',
                 ],
                 'required': [
                     'template_id',
@@ -419,12 +425,16 @@ class TemplateApi(object):
                 'openapi_types': {
                     'template_id':
                         (str,),
+                    'force_download':
+                        (bool,),
                 },
                 'attribute_map': {
                     'template_id': 'template_id',
+                    'force_download': 'force_download',
                 },
                 'location_map': {
                     'template_id': 'path',
+                    'force_download': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -1081,6 +1091,7 @@ class TemplateApi(object):
 
         Keyword Args:
             file_type (str): Set to `pdf` for a single merged document or `zip` for a collection of individual documents.. [optional]
+            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -1281,6 +1292,7 @@ class TemplateApi(object):
             template_id (str): The id of the template files to retrieve.
 
         Keyword Args:
+            force_download (bool): By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of True
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/python/dropbox_sign/api/template_api.py
+++ b/sdks/python/dropbox_sign/api/template_api.py
@@ -1286,7 +1286,7 @@ class TemplateApi(object):
             template_id (str): The id of the template files to retrieve.
 
         Keyword Args:
-            force_download (int): By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
+            force_download (int): By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.. [optional] if omitted the server will use the default value of 1
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -562,6 +562,7 @@ end
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &#39;pdf&#39;] |
+| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
 
 ### Return type
 
@@ -651,7 +652,7 @@ end
 
 ## `signature_request_files_as_file_url`
 
-> `<FileResponse> signature_request_files_as_file_url(signature_request_id)`
+> `<FileResponse> signature_request_files_as_file_url(signature_request_id, opts)`
 
 Download Files as File Url
 
@@ -687,12 +688,12 @@ end
 
 This returns an Array which contains the response data, status code and headers.
 
-> `<Array(<FileResponse>, Integer, Hash)> signature_request_files_as_file_url_with_http_info(signature_request_id)`
+> `<Array(<FileResponse>, Integer, Hash)> signature_request_files_as_file_url_with_http_info(signature_request_id, opts)`
 
 ```ruby
 begin
   # Download Files as File Url
-  data, status_code, headers = api_instance.signature_request_files_as_file_url_with_http_info(signature_request_id)
+  data, status_code, headers = api_instance.signature_request_files_as_file_url_with_http_info(signature_request_id, opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => <FileResponse>
@@ -706,6 +707,7 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
+| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
 
 ### Return type
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -562,6 +562,7 @@ end
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &#39;pdf&#39;] |
+| `force_download` | **Integer** | If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -706,7 +706,7 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
-| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
+| `force_download` | **Integer** | By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -562,7 +562,7 @@ end
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &#39;pdf&#39;] |
-| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
+| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 
@@ -707,7 +707,7 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
-| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
+| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -562,7 +562,6 @@ end
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &#39;pdf&#39;] |
-| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -562,7 +562,6 @@ end
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &#39;pdf&#39;] |
-| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to true] |
 
 ### Return type
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -562,7 +562,7 @@ end
 | ---- | ---- | ----------- | ----- |
 | `signature_request_id` | **String** | The id of the SignatureRequest to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional][default to &#39;pdf&#39;] |
-| `force_download` | **Integer** | If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to 1] |
+| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded. | [optional][default to true] |
 
 ### Return type
 

--- a/sdks/ruby/docs/TemplateApi.md
+++ b/sdks/ruby/docs/TemplateApi.md
@@ -425,7 +425,7 @@ end
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **String** | The id of the template files to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
+| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 
@@ -570,7 +570,7 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **String** | The id of the template files to retrieve. |  |
-| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
+| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/TemplateApi.md
+++ b/sdks/ruby/docs/TemplateApi.md
@@ -569,7 +569,7 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **String** | The id of the template files to retrieve. |  |
-| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
+| `force_download` | **Integer** | By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/TemplateApi.md
+++ b/sdks/ruby/docs/TemplateApi.md
@@ -425,7 +425,6 @@ end
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **String** | The id of the template files to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
-| `force_download` | **Integer** | By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser. | [optional][default to 1] |
 
 ### Return type
 

--- a/sdks/ruby/docs/TemplateApi.md
+++ b/sdks/ruby/docs/TemplateApi.md
@@ -425,6 +425,7 @@ end
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **String** | The id of the template files to retrieve. |  |
 | `file_type` | **String** | Set to `pdf` for a single merged document or `zip` for a collection of individual documents. | [optional] |
+| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
 
 ### Return type
 
@@ -514,7 +515,7 @@ end
 
 ## `template_files_as_file_url`
 
-> `<FileResponse> template_files_as_file_url(template_id)`
+> `<FileResponse> template_files_as_file_url(template_id, opts)`
 
 Get Template Files as File Url
 
@@ -550,12 +551,12 @@ end
 
 This returns an Array which contains the response data, status code and headers.
 
-> `<Array(<FileResponse>, Integer, Hash)> template_files_as_file_url_with_http_info(template_id)`
+> `<Array(<FileResponse>, Integer, Hash)> template_files_as_file_url_with_http_info(template_id, opts)`
 
 ```ruby
 begin
   # Get Template Files as File Url
-  data, status_code, headers = api_instance.template_files_as_file_url_with_http_info(template_id)
+  data, status_code, headers = api_instance.template_files_as_file_url_with_http_info(template_id, opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => <FileResponse>
@@ -569,6 +570,7 @@ end
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | `template_id` | **String** | The id of the template files to retrieve. |  |
+| `force_download` | **Boolean** | By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser. | [optional][default to true] |
 
 ### Return type
 

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -724,7 +724,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the `signature_request_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead.
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
+    # @option opts [Integer] :force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [FileResponse]
     def signature_request_files_as_file_url(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_as_file_url_with_http_info(signature_request_id, opts)
@@ -735,7 +735,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
+    # @option opts [Integer] :force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(FileResponse, Integer, Hash)>] FileResponse data, response status code and response headers
     def signature_request_files_as_file_url_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -530,7 +530,6 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (default to 'pdf')
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (default to true)
     # @return [File]
     def signature_request_files(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_with_http_info(signature_request_id, opts)
@@ -542,7 +541,6 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def signature_request_files_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging
@@ -562,7 +560,6 @@ module Dropbox::Sign
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'file_type'] = opts[:'file_type'] if !opts[:'file_type'].nil?
-      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -530,7 +530,6 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (default to 'pdf')
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [File]
     def signature_request_files(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_with_http_info(signature_request_id, opts)
@@ -542,7 +541,6 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def signature_request_files_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging
@@ -562,7 +560,6 @@ module Dropbox::Sign
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'file_type'] = opts[:'file_type'] if !opts[:'file_type'].nil?
-      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -530,6 +530,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (default to 'pdf')
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
     # @return [File]
     def signature_request_files(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_with_http_info(signature_request_id, opts)
@@ -541,6 +542,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def signature_request_files_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging
@@ -560,6 +562,7 @@ module Dropbox::Sign
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'file_type'] = opts[:'file_type'] if !opts[:'file_type'].nil?
+      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}
@@ -724,6 +727,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the `signature_request_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead.
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
     # @return [FileResponse]
     def signature_request_files_as_file_url(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_as_file_url_with_http_info(signature_request_id, opts)
@@ -734,6 +738,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(FileResponse, Integer, Hash)>] FileResponse data, response status code and response headers
     def signature_request_files_as_file_url_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging
@@ -748,6 +753,7 @@ module Dropbox::Sign
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -530,7 +530,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (default to 'pdf')
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [File]
     def signature_request_files(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_with_http_info(signature_request_id, opts)
@@ -542,7 +542,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def signature_request_files_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging
@@ -727,7 +727,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the `signature_request_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead.
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [FileResponse]
     def signature_request_files_as_file_url(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_as_file_url_with_http_info(signature_request_id, opts)
@@ -738,7 +738,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the &#x60;signature_request_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead.
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(FileResponse, Integer, Hash)>] FileResponse data, response status code and response headers
     def signature_request_files_as_file_url_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -530,6 +530,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (default to 'pdf')
+    # @option opts [Integer] :force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (default to 1)
     # @return [File]
     def signature_request_files(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_with_http_info(signature_request_id, opts)
@@ -541,6 +542,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+    # @option opts [Integer] :force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def signature_request_files_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging
@@ -560,6 +562,7 @@ module Dropbox::Sign
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'file_type'] = opts[:'file_type'] if !opts[:'file_type'].nil?
+      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -530,7 +530,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents. (default to 'pdf')
-    # @option opts [Integer] :force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (default to 1)
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded. (default to true)
     # @return [File]
     def signature_request_files(signature_request_id, opts = {})
       data, _status_code, _headers = signature_request_files_with_http_info(signature_request_id, opts)
@@ -542,7 +542,7 @@ module Dropbox::Sign
     # @param signature_request_id [String] The id of the SignatureRequest to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Integer] :force_download If set to &#x60;1&#x60;, browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.  **Note**: If &#x60;file_type&#x60; is set to &#x60;zip&#x60; this parameter will be ignored and the file will always be downloaded.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def signature_request_files_with_http_info(signature_request_id, opts = {})
       if @api_client.config.debugging

--- a/sdks/ruby/lib/dropbox-sign/api/template_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/template_api.rb
@@ -427,7 +427,6 @@ module Dropbox::Sign
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [File]
     def template_files(template_id, opts = {})
       data, _status_code, _headers = template_files_with_http_info(template_id, opts)
@@ -439,7 +438,6 @@ module Dropbox::Sign
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def template_files_with_http_info(template_id, opts = {})
       if @api_client.config.debugging
@@ -459,7 +457,6 @@ module Dropbox::Sign
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'file_type'] = opts[:'file_type'] if !opts[:'file_type'].nil?
-      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/sdks/ruby/lib/dropbox-sign/api/template_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/template_api.rb
@@ -621,7 +621,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
+    # @option opts [Integer] :force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [FileResponse]
     def template_files_as_file_url(template_id, opts = {})
       data, _status_code, _headers = template_files_as_file_url_with_http_info(template_id, opts)
@@ -632,7 +632,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
+    # @option opts [Integer] :force_download By default when opening the &#x60;file_url&#x60; a browser will download the PDF and save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(FileResponse, Integer, Hash)>] FileResponse data, response status code and response headers
     def template_files_as_file_url_with_http_info(template_id, opts = {})
       if @api_client.config.debugging

--- a/sdks/ruby/lib/dropbox-sign/api/template_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/template_api.rb
@@ -427,6 +427,7 @@ module Dropbox::Sign
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
     # @return [File]
     def template_files(template_id, opts = {})
       data, _status_code, _headers = template_files_with_http_info(template_id, opts)
@@ -438,6 +439,7 @@ module Dropbox::Sign
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def template_files_with_http_info(template_id, opts = {})
       if @api_client.config.debugging
@@ -457,6 +459,7 @@ module Dropbox::Sign
       # query parameters
       query_params = opts[:query_params] || {}
       query_params[:'file_type'] = opts[:'file_type'] if !opts[:'file_type'].nil?
+      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}
@@ -621,6 +624,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
     # @return [FileResponse]
     def template_files_as_file_url(template_id, opts = {})
       data, _status_code, _headers = template_files_as_file_url_with_http_info(template_id, opts)
@@ -631,6 +635,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
+    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(FileResponse, Integer, Hash)>] FileResponse data, response status code and response headers
     def template_files_as_file_url_with_http_info(template_id, opts = {})
       if @api_client.config.debugging
@@ -645,6 +650,7 @@ module Dropbox::Sign
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'force_download'] = opts[:'force_download'] if !opts[:'force_download'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/sdks/ruby/lib/dropbox-sign/api/template_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/template_api.rb
@@ -427,7 +427,7 @@ module Dropbox::Sign
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [File]
     def template_files(template_id, opts = {})
       data, _status_code, _headers = template_files_with_http_info(template_id, opts)
@@ -439,7 +439,7 @@ module Dropbox::Sign
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
     # @option opts [String] :file_type Set to &#x60;pdf&#x60; for a single merged document or &#x60;zip&#x60; for a collection of individual documents.
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(File, Integer, Hash)>] File data, response status code and response headers
     def template_files_with_http_info(template_id, opts = {})
       if @api_client.config.debugging
@@ -624,7 +624,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser. (default to true)
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser. (default to 1)
     # @return [FileResponse]
     def template_files_as_file_url(template_id, opts = {})
       data, _status_code, _headers = template_files_as_file_url_with_http_info(template_id, opts)
@@ -635,7 +635,7 @@ module Dropbox::Sign
     # Obtain a copy of the current documents specified by the &#x60;template_id&#x60; parameter. Returns a JSON object with a url to the file (PDFs only).  If the files are currently being prepared, a status code of &#x60;409&#x60; will be returned instead. In this case please wait for the &#x60;template_created&#x60; callback event.
     # @param template_id [String] The id of the template files to retrieve.
     # @param [Hash] opts the optional parameters
-    # @option opts [Boolean] :force_download By default the browser will download the file save it locally. When set to &#x60;false&#x60; the PDF file will be displayed in the browser.
+    # @option opts [Integer] :force_download By default the browser will download the file save it locally. When set to &#x60;0&#x60; the PDF file will be displayed in the browser.
     # @return [Array<(FileResponse, Integer, Hash)>] FileResponse data, response status code and response headers
     def template_files_as_file_url_with_http_info(template_id, opts = {})
       if @api_client.config.debugging

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -305,10 +305,7 @@
   If the files are currently being prepared, a status code of `409` will be returned instead.
 "SignatureRequestFiles::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to retrieve.
 "SignatureRequestFiles::FILE_TYPE": Set to `pdf` for a single merged document or `zip` for a collection of individual documents.
-"SignatureRequestFiles::FORCE_DOWNLOAD": |-
-  By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
-
-  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
+"SignatureRequestFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
 "SignatureRequestFiles::GET_DATA_URI": If `true`, the response will contain the file as base64 encoded string. Base64 encoding is only available for PDFs.
 "SignatureRequestFiles::GET_URL": If `true`, the response will contain a url link to the file instead. Links are only available for PDFs and have a TTL of 3 days.
 
@@ -613,6 +610,7 @@
   Obtain a copy of the current documents specified by the `template_id` parameter. Returns a PDF or ZIP file.
 
   If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
+"TemplateFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
 "TemplateFilesAsFileUrl::SUMMARY": Get Template Files as File Url
 "TemplateFilesAsFileUrl::DESCRIPTION": |-
   Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -305,7 +305,7 @@
   If the files are currently being prepared, a status code of `409` will be returned instead.
 "SignatureRequestFiles::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to retrieve.
 "SignatureRequestFiles::FILE_TYPE": Set to `pdf` for a single merged document or `zip` for a collection of individual documents.
-"SignatureRequestFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
+"SignatureRequestFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
 "SignatureRequestFiles::GET_DATA_URI": If `true`, the response will contain the file as base64 encoded string. Base64 encoding is only available for PDFs.
 "SignatureRequestFiles::GET_URL": If `true`, the response will contain a url link to the file instead. Links are only available for PDFs and have a TTL of 3 days.
 
@@ -610,7 +610,7 @@
   Obtain a copy of the current documents specified by the `template_id` parameter. Returns a PDF or ZIP file.
 
   If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
-"TemplateFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
+"TemplateFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
 "TemplateFilesAsFileUrl::SUMMARY": Get Template Files as File Url
 "TemplateFilesAsFileUrl::DESCRIPTION": |-
   Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -306,7 +306,7 @@
 "SignatureRequestFiles::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to retrieve.
 "SignatureRequestFiles::FILE_TYPE": Set to `pdf` for a single merged document or `zip` for a collection of individual documents.
 "SignatureRequestFiles::FORCE_DOWNLOAD": |-
-  If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+  By default the browser will download the file save it locally. When set to `false` the PDF file will be displayed in the browser.
 
   **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
 "SignatureRequestFiles::GET_DATA_URI": If `true`, the response will contain the file as base64 encoded string. Base64 encoding is only available for PDFs.

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -305,7 +305,7 @@
   If the files are currently being prepared, a status code of `409` will be returned instead.
 "SignatureRequestFiles::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to retrieve.
 "SignatureRequestFiles::FILE_TYPE": Set to `pdf` for a single merged document or `zip` for a collection of individual documents.
-"SignatureRequestFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+"SignatureRequestFiles::FORCE_DOWNLOAD": By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.
 "SignatureRequestFiles::GET_DATA_URI": If `true`, the response will contain the file as base64 encoded string. Base64 encoding is only available for PDFs.
 "SignatureRequestFiles::GET_URL": If `true`, the response will contain a url link to the file instead. Links are only available for PDFs and have a TTL of 3 days.
 
@@ -610,7 +610,7 @@
   Obtain a copy of the current documents specified by the `template_id` parameter. Returns a PDF or ZIP file.
 
   If the files are currently being prepared, a status code of `409` will be returned instead. In this case please wait for the `template_created` callback event.
-"TemplateFiles::FORCE_DOWNLOAD": By default the browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+"TemplateFiles::FORCE_DOWNLOAD": By default when opening the `file_url` a browser will download the PDF and save it locally. When set to `0` the PDF file will be displayed in the browser.
 "TemplateFilesAsFileUrl::SUMMARY": Get Template Files as File Url
 "TemplateFilesAsFileUrl::DESCRIPTION": |-
   Obtain a copy of the current documents specified by the `template_id` parameter. Returns a JSON object with a url to the file (PDFs only).

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -305,6 +305,10 @@
   If the files are currently being prepared, a status code of `409` will be returned instead.
 "SignatureRequestFiles::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to retrieve.
 "SignatureRequestFiles::FILE_TYPE": Set to `pdf` for a single merged document or `zip` for a collection of individual documents.
+"SignatureRequestFiles::FORCE_DOWNLOAD": |-
+  If set to `1`, browser will download the file save it locally. When set to `0` the PDF file will be displayed in the browser.
+
+  **Note**: If `file_type` is set to `zip` this parameter will be ignored and the file will always be downloaded.
 "SignatureRequestFiles::GET_DATA_URI": If `true`, the response will contain the file as base64 encoded string. Base64 encoding is only available for PDFs.
 "SignatureRequestFiles::GET_URL": If `true`, the response will contain a url link to the file instead. Links are only available for PDFs and have a TTL of 3 days.
 


### PR DESCRIPTION
Add param for controlling whether signature request pdf file will be dwnloaded or displayed in the browser.