### PR TITLE
Reject network calls if response status doesn't fall into considered values

### DIFF
--- a/sdks/node/api/accountApi.ts
+++ b/sdks/node/api/accountApi.ts
@@ -287,6 +287,8 @@ export class AccountApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -425,6 +427,8 @@ export class AccountApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -586,6 +590,8 @@ export class AccountApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -751,6 +757,8 @@ export class AccountApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/api/apiAppApi.ts
+++ b/sdks/node/api/apiAppApi.ts
@@ -281,6 +281,8 @@ export class ApiAppApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -403,6 +405,8 @@ export class ApiAppApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -536,6 +540,8 @@ export class ApiAppApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -673,6 +679,8 @@ export class ApiAppApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -848,6 +856,8 @@ export class ApiAppApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });

--- a/sdks/node/api/bulkSendJobApi.ts
+++ b/sdks/node/api/bulkSendJobApi.ts
@@ -273,6 +273,8 @@ export class BulkSendJobApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -415,6 +417,8 @@ export class BulkSendJobApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/api/embeddedApi.ts
+++ b/sdks/node/api/embeddedApi.ts
@@ -301,6 +301,8 @@ export class EmbeddedApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -439,6 +441,8 @@ export class EmbeddedApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/api/oAuthApi.ts
+++ b/sdks/node/api/oAuthApi.ts
@@ -257,6 +257,8 @@ export class OAuthApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -396,6 +398,8 @@ export class OAuthApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });

--- a/sdks/node/api/reportApi.ts
+++ b/sdks/node/api/reportApi.ts
@@ -278,6 +278,8 @@ export class ReportApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -295,6 +295,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -467,6 +469,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -590,6 +594,8 @@ export class SignatureRequestApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -759,6 +765,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -931,6 +939,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1071,6 +1081,8 @@ export class SignatureRequestApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -1208,6 +1220,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1351,6 +1365,8 @@ export class SignatureRequestApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -1488,6 +1504,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1648,6 +1666,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1786,6 +1806,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1970,6 +1992,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -2088,6 +2112,8 @@ export class SignatureRequestApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -2257,6 +2283,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -2428,6 +2456,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -2612,6 +2642,8 @@ export class SignatureRequestApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/api/teamApi.ts
+++ b/sdks/node/api/teamApi.ts
@@ -295,6 +295,8 @@ export class TeamApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -453,6 +455,8 @@ export class TeamApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -561,6 +565,8 @@ export class TeamApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -680,6 +686,8 @@ export class TeamApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -812,6 +820,8 @@ export class TeamApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -945,6 +955,8 @@ export class TeamApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1101,6 +1113,8 @@ export class TeamApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1266,6 +1280,8 @@ export class TeamApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -1421,6 +1437,8 @@ export class TeamApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1580,6 +1598,8 @@ export class TeamApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });

--- a/sdks/node/api/templateApi.ts
+++ b/sdks/node/api/templateApi.ts
@@ -310,6 +310,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -476,6 +478,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -646,6 +650,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -769,6 +775,8 @@ export class TemplateApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -908,6 +916,8 @@ export class TemplateApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -1045,6 +1055,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1188,6 +1200,8 @@ export class TemplateApi {
               reject(new HttpError(response, body, response.status));
               return;
             }
+
+            reject(error);
           }
         );
       });
@@ -1325,6 +1339,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1485,6 +1501,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1668,6 +1686,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -1852,6 +1872,8 @@ export class TemplateApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/api/unclaimedDraftApi.ts
+++ b/sdks/node/api/unclaimedDraftApi.ts
@@ -290,6 +290,8 @@ export class UnclaimedDraftApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -460,6 +462,8 @@ export class UnclaimedDraftApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -632,6 +636,8 @@ export class UnclaimedDraftApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }
@@ -816,6 +822,8 @@ export class UnclaimedDraftApi {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+
+              reject(error);
             }
           );
         }

--- a/sdks/node/dist/api.js
+++ b/sdks/node/dist/api.js
@@ -29134,6 +29134,7 @@ var AccountApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -29238,6 +29239,7 @@ var AccountApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -29357,6 +29359,7 @@ var AccountApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -29480,6 +29483,7 @@ var AccountApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -29654,6 +29658,7 @@ var ApiAppApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -29744,6 +29749,7 @@ var ApiAppApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -29843,6 +29849,7 @@ var ApiAppApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -29946,6 +29953,7 @@ var ApiAppApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -30073,6 +30081,7 @@ var ApiAppApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -30242,6 +30251,7 @@ var BulkSendJobApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -30350,6 +30360,7 @@ var BulkSendJobApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -30536,6 +30547,7 @@ var EmbeddedApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -30640,6 +30652,7 @@ var EmbeddedApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -30794,6 +30807,7 @@ var OAuthApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -30893,6 +30907,7 @@ var OAuthApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -31065,6 +31080,7 @@ var ReportApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -31238,6 +31254,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -31362,6 +31379,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -31453,6 +31471,7 @@ var SignatureRequestApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -31576,6 +31595,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -31700,6 +31720,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -31803,6 +31824,7 @@ var SignatureRequestApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -31906,6 +31928,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32012,6 +32035,7 @@ var SignatureRequestApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -32115,6 +32139,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32235,6 +32260,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32339,6 +32365,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32471,6 +32498,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32557,6 +32585,7 @@ var SignatureRequestApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -32680,6 +32709,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32804,6 +32834,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -32936,6 +32967,7 @@ var SignatureRequestApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -33116,6 +33148,7 @@ var TeamApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -33232,6 +33265,7 @@ var TeamApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -33314,6 +33348,7 @@ var TeamApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -33405,6 +33440,7 @@ var TeamApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -33506,6 +33542,7 @@ var TeamApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -33608,6 +33645,7 @@ var TeamApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -33724,6 +33762,7 @@ var TeamApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -33844,6 +33883,7 @@ var TeamApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -33959,6 +33999,7 @@ var TeamApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -34076,6 +34117,7 @@ var TeamApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -34261,6 +34303,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -34385,6 +34428,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -34509,6 +34553,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -34600,6 +34645,7 @@ var TemplateApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -34702,6 +34748,7 @@ var TemplateApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -34805,6 +34852,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -34911,6 +34959,7 @@ var TemplateApi = class {
                 reject(new HttpError(response, body, response.status));
                 return;
               }
+              reject(error);
             }
           );
         });
@@ -35014,6 +35063,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35134,6 +35184,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35266,6 +35317,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35398,6 +35450,7 @@ var TemplateApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35576,6 +35629,7 @@ var UnclaimedDraftApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35700,6 +35754,7 @@ var UnclaimedDraftApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35824,6 +35879,7 @@ var UnclaimedDraftApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }
@@ -35956,6 +36012,7 @@ var UnclaimedDraftApi = class {
                   reject(new HttpError(response, body, response.status));
                   return;
                 }
+                reject(error);
               }
             );
           }

--- a/sdks/node/templates/api-single.mustache
+++ b/sdks/node/templates/api-single.mustache
@@ -341,6 +341,8 @@ export class {{classname}} {
                         {{/isWildcard}}
                         {{/dataType}}
                         {{/responses}}
+
+                        reject(error);
                     });
             });
         });


### PR DESCRIPTION
When a network call is made by the NodeJS SDK, if there is an error the status code is checked to reject the promise, but if the status code doesn't have any of the considered values, the promises never settles.

Added a generic error rejection to settle the promise if a network call fails for any other reason than the considered before.