### PR TITLE
Add note about document charges in edit endpoints

### DIFF
--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2231,7 +2231,10 @@ paths:
       tags:
         - 'Signature Request'
       summary: 'Edit Signature Request'
-      description: 'Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.'
+      description: |-
+        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+
+        **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
       operationId: signatureRequestEdit
       parameters:
         -
@@ -2355,7 +2358,10 @@ paths:
       tags:
         - 'Signature Request'
       summary: 'Edit Signature Request With Template'
-      description: 'Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.'
+      description: |-
+        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+
+        **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
       operationId: signatureRequestEditWithTemplate
       parameters:
         -

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2234,7 +2234,7 @@ paths:
       description: |-
         Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
 
-        **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
       operationId: signatureRequestEdit
       parameters:
         -
@@ -2361,7 +2361,7 @@ paths:
       description: |-
         Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
 
-        **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
       operationId: signatureRequestEditWithTemplate
       parameters:
         -

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -2234,7 +2234,7 @@ paths:
       description: |-
         Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
 
-        **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        **NOTE:** Edit and resend will not deduct your signature request quota.
       operationId: signatureRequestEdit
       parameters:
         -
@@ -2361,7 +2361,7 @@ paths:
       description: |-
         Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
 
-        **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        **NOTE:** Edit and resend will not deduct your signature request quota.
       operationId: signatureRequestEditWithTemplate
       parameters:
         -

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -657,7 +657,7 @@ catch (ApiException e)
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 ```csharp
@@ -806,7 +806,7 @@ catch (ApiException e)
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 ```csharp

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -657,7 +657,7 @@ catch (ApiException e)
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 ```csharp
@@ -806,7 +806,7 @@ catch (ApiException e)
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 ```csharp

--- a/sdks/dotnet/docs/SignatureRequestApi.md
+++ b/sdks/dotnet/docs/SignatureRequestApi.md
@@ -657,7 +657,7 @@ catch (ApiException e)
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 ```csharp
@@ -806,7 +806,7 @@ catch (ApiException e)
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 ```csharp

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -146,7 +146,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -159,7 +159,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -171,7 +171,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -184,7 +184,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -597,7 +597,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -611,7 +611,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -624,7 +624,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -638,7 +638,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -1938,7 +1938,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -1952,7 +1952,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2036,7 +2036,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2051,7 +2051,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2138,7 +2138,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2152,7 +2152,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2236,7 +2236,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2251,7 +2251,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -146,7 +146,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -159,7 +159,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -171,7 +171,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -184,7 +184,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -597,7 +597,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -611,7 +611,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -624,7 +624,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -638,7 +638,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -1938,7 +1938,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -1952,7 +1952,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2036,7 +2036,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2051,7 +2051,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2138,7 +2138,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2152,7 +2152,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2236,7 +2236,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2251,7 +2251,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>

--- a/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Api/SignatureRequestApi.cs
@@ -146,7 +146,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -159,7 +159,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -171,7 +171,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -184,7 +184,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -597,7 +597,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -611,7 +611,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -624,7 +624,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -638,7 +638,7 @@ namespace Dropbox.Sign.Api
         /// Edit Signature Request With Template
         /// </summary>
         /// <remarks>
-        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </remarks>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -1938,7 +1938,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -1952,7 +1952,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2036,7 +2036,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2051,7 +2051,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2138,7 +2138,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2152,7 +2152,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2236,7 +2236,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>
@@ -2251,7 +2251,7 @@ namespace Dropbox.Sign.Api
         }
 
         /// <summary>
-        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+        /// Edit Signature Request With Template Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
         /// </summary>
         /// <exception cref="Dropbox.Sign.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="signatureRequestId">The id of the SignatureRequest to edit.</param>

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -567,7 +567,7 @@ Edit Signature Request
 
 Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
 
-**NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+**NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 
@@ -685,7 +685,7 @@ Edit Signature Request With Template
 
 Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
 
-**NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+**NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -567,7 +567,7 @@ Edit Signature Request
 
 Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
 
-**NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+**NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 
@@ -685,7 +685,7 @@ Edit Signature Request With Template
 
 Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
 
-**NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+**NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 

--- a/sdks/java/docs/SignatureRequestApi.md
+++ b/sdks/java/docs/SignatureRequestApi.md
@@ -567,6 +567,8 @@ Edit Signature Request
 
 Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
 
+**NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+
 ### Example
 
 ```java
@@ -682,6 +684,8 @@ Name | Type | Description  | Notes
 Edit Signature Request With Template
 
 Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+
+**NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -436,7 +436,7 @@ public class SignatureRequestApi {
   }
   /**
    * Edit Signature Request
-   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditRequest  (required)
    * @return SignatureRequestGetResponse
@@ -455,7 +455,7 @@ public class SignatureRequestApi {
 
   /**
    * Edit Signature Request
-   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditRequest  (required)
    * @return ApiResponse&lt;SignatureRequestGetResponse&gt;
@@ -519,7 +519,7 @@ public class SignatureRequestApi {
   }
   /**
    * Edit Signature Request With Template
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditWithTemplateRequest  (required)
    * @return SignatureRequestGetResponse
@@ -538,7 +538,7 @@ public class SignatureRequestApi {
 
   /**
    * Edit Signature Request With Template
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditWithTemplateRequest  (required)
    * @return ApiResponse&lt;SignatureRequestGetResponse&gt;

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -436,7 +436,7 @@ public class SignatureRequestApi {
   }
   /**
    * Edit Signature Request
-   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditRequest  (required)
    * @return SignatureRequestGetResponse
@@ -455,7 +455,7 @@ public class SignatureRequestApi {
 
   /**
    * Edit Signature Request
-   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditRequest  (required)
    * @return ApiResponse&lt;SignatureRequestGetResponse&gt;
@@ -519,7 +519,7 @@ public class SignatureRequestApi {
   }
   /**
    * Edit Signature Request With Template
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditWithTemplateRequest  (required)
    * @return SignatureRequestGetResponse
@@ -538,7 +538,7 @@ public class SignatureRequestApi {
 
   /**
    * Edit Signature Request With Template
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditWithTemplateRequest  (required)
    * @return ApiResponse&lt;SignatureRequestGetResponse&gt;

--- a/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
+++ b/sdks/java/src/main/java/com/dropbox/sign/api/SignatureRequestApi.java
@@ -436,7 +436,7 @@ public class SignatureRequestApi {
   }
   /**
    * Edit Signature Request
-   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditRequest  (required)
    * @return SignatureRequestGetResponse
@@ -455,7 +455,7 @@ public class SignatureRequestApi {
 
   /**
    * Edit Signature Request
-   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+   * Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditRequest  (required)
    * @return ApiResponse&lt;SignatureRequestGetResponse&gt;
@@ -519,7 +519,7 @@ public class SignatureRequestApi {
   }
   /**
    * Edit Signature Request With Template
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditWithTemplateRequest  (required)
    * @return SignatureRequestGetResponse
@@ -538,7 +538,7 @@ public class SignatureRequestApi {
 
   /**
    * Edit Signature Request With Template
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
    * @param signatureRequestId The id of the SignatureRequest to edit. (required)
    * @param signatureRequestEditWithTemplateRequest  (required)
    * @return ApiResponse&lt;SignatureRequestGetResponse&gt;

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -950,7 +950,7 @@ export class SignatureRequestApi {
     });
   }
   /**
-   * Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+   * Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
    * @summary Edit Signature Request
    * @param signatureRequestId The id of the SignatureRequest to edit.
    * @param signatureRequestEditRequest
@@ -1136,7 +1136,7 @@ export class SignatureRequestApi {
     });
   }
   /**
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
    * @summary Edit Signature Request With Template
    * @param signatureRequestId The id of the SignatureRequest to edit.
    * @param signatureRequestEditWithTemplateRequest

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -950,7 +950,7 @@ export class SignatureRequestApi {
     });
   }
   /**
-   * Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+   * Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
    * @summary Edit Signature Request
    * @param signatureRequestId The id of the SignatureRequest to edit.
    * @param signatureRequestEditRequest
@@ -1136,7 +1136,7 @@ export class SignatureRequestApi {
     });
   }
   /**
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
    * @summary Edit Signature Request With Template
    * @param signatureRequestId The id of the SignatureRequest to edit.
    * @param signatureRequestEditWithTemplateRequest

--- a/sdks/node/api/signatureRequestApi.ts
+++ b/sdks/node/api/signatureRequestApi.ts
@@ -950,7 +950,7 @@ export class SignatureRequestApi {
     });
   }
   /**
-   * Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+   * Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
    * @summary Edit Signature Request
    * @param signatureRequestId The id of the SignatureRequest to edit.
    * @param signatureRequestEditRequest
@@ -1136,7 +1136,7 @@ export class SignatureRequestApi {
     });
   }
   /**
-   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+   * Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
    * @summary Edit Signature Request With Template
    * @param signatureRequestId The id of the SignatureRequest to edit.
    * @param signatureRequestEditWithTemplateRequest

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -742,7 +742,7 @@ signatureRequestEdit(signatureRequestId: string, signatureRequestEditRequest: Si
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### TypeScript Example
 
@@ -957,7 +957,7 @@ signatureRequestEditWithTemplate(signatureRequestId: string, signatureRequestEdi
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### TypeScript Example
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -742,7 +742,7 @@ signatureRequestEdit(signatureRequestId: string, signatureRequestEditRequest: Si
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### TypeScript Example
 
@@ -957,7 +957,7 @@ signatureRequestEditWithTemplate(signatureRequestId: string, signatureRequestEdi
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### TypeScript Example
 

--- a/sdks/node/docs/api/SignatureRequestApi.md
+++ b/sdks/node/docs/api/SignatureRequestApi.md
@@ -742,7 +742,7 @@ signatureRequestEdit(signatureRequestId: string, signatureRequestEditRequest: Si
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### TypeScript Example
 
@@ -957,7 +957,7 @@ signatureRequestEditWithTemplate(signatureRequestId: string, signatureRequestEdi
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### TypeScript Example
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -468,7 +468,7 @@ signatureRequestEdit($signature_request_id, $signature_request_edit_request): \D
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 
@@ -570,7 +570,7 @@ signatureRequestEditWithTemplate($signature_request_id, $signature_request_edit_
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -468,7 +468,7 @@ signatureRequestEdit($signature_request_id, $signature_request_edit_request): \D
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 
@@ -570,7 +570,7 @@ signatureRequestEditWithTemplate($signature_request_id, $signature_request_edit_
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 

--- a/sdks/php/docs/Api/SignatureRequestApi.md
+++ b/sdks/php/docs/Api/SignatureRequestApi.md
@@ -468,7 +468,7 @@ signatureRequestEdit($signature_request_id, $signature_request_edit_request): \D
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 
@@ -570,7 +570,7 @@ signatureRequestEditWithTemplate($signature_request_id, $signature_request_edit_
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -515,7 +515,7 @@ with ApiClient(configuration) as api_client:
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 
@@ -628,7 +628,7 @@ with ApiClient(configuration) as api_client:
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Example
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -515,7 +515,7 @@ with ApiClient(configuration) as api_client:
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 
@@ -628,7 +628,7 @@ with ApiClient(configuration) as api_client:
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Example
 

--- a/sdks/python/docs/SignatureRequestApi.md
+++ b/sdks/python/docs/SignatureRequestApi.md
@@ -515,7 +515,7 @@ with ApiClient(configuration) as api_client:
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 
@@ -628,7 +628,7 @@ with ApiClient(configuration) as api_client:
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Example
 

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -1546,7 +1546,7 @@ class SignatureRequestApi(object):
     ) -> SignatureRequestGetResponse:
         """Edit Signature Request  # noqa: E501
 
-        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  # noqa: E501
+        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -1650,7 +1650,7 @@ class SignatureRequestApi(object):
     ) -> SignatureRequestGetResponse:
         """Edit Signature Request With Template  # noqa: E501
 
-        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  # noqa: E501
+        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -1546,7 +1546,7 @@ class SignatureRequestApi(object):
     ) -> SignatureRequestGetResponse:
         """Edit Signature Request  # noqa: E501
 
-        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).  # noqa: E501
+        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -1650,7 +1650,7 @@ class SignatureRequestApi(object):
     ) -> SignatureRequestGetResponse:
         """Edit Signature Request With Template  # noqa: E501
 
-        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).  # noqa: E501
+        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/sdks/python/dropbox_sign/api/signature_request_api.py
+++ b/sdks/python/dropbox_sign/api/signature_request_api.py
@@ -1546,7 +1546,7 @@ class SignatureRequestApi(object):
     ) -> SignatureRequestGetResponse:
         """Edit Signature Request  # noqa: E501
 
-        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.  # noqa: E501
+        Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -1650,7 +1650,7 @@ class SignatureRequestApi(object):
     ) -> SignatureRequestGetResponse:
         """Edit Signature Request With Template  # noqa: E501
 
-        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.  # noqa: E501
+        Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -512,7 +512,7 @@ end
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Examples
 
@@ -623,7 +623,7 @@ end
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 
 ### Examples
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -512,7 +512,7 @@ end
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Examples
 
@@ -623,7 +623,7 @@ end
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 
 ### Examples
 

--- a/sdks/ruby/docs/SignatureRequestApi.md
+++ b/sdks/ruby/docs/SignatureRequestApi.md
@@ -512,7 +512,7 @@ end
 
 Edit Signature Request
 
-Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Examples
 
@@ -623,7 +623,7 @@ end
 
 Edit Signature Request With Template
 
-Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
 
 ### Examples
 

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -526,7 +526,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request
-    # Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+    # Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_request [SignatureRequestEditRequest] 
     # @param [Hash] opts the optional parameters
@@ -537,7 +537,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request
-    # Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+    # Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_request [SignatureRequestEditRequest] 
     # @param [Hash] opts the optional parameters
@@ -641,7 +641,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request With Template
-    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_with_template_request [SignatureRequestEditWithTemplateRequest] 
     # @param [Hash] opts the optional parameters
@@ -652,7 +652,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request With Template
-    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_with_template_request [SignatureRequestEditWithTemplateRequest] 
     # @param [Hash] opts the optional parameters

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -526,7 +526,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request
-    # Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+    # Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_request [SignatureRequestEditRequest] 
     # @param [Hash] opts the optional parameters
@@ -537,7 +537,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request
-    # Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+    # Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_request [SignatureRequestEditRequest] 
     # @param [Hash] opts the optional parameters
@@ -641,7 +641,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request With Template
-    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_with_template_request [SignatureRequestEditWithTemplateRequest] 
     # @param [Hash] opts the optional parameters
@@ -652,7 +652,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request With Template
-    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_with_template_request [SignatureRequestEditWithTemplateRequest] 
     # @param [Hash] opts the optional parameters

--- a/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
+++ b/sdks/ruby/lib/dropbox-sign/api/signature_request_api.rb
@@ -526,7 +526,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request
-    # Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+    # Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_request [SignatureRequestEditRequest] 
     # @param [Hash] opts the optional parameters
@@ -537,7 +537,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request
-    # Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+    # Edits and sends a SignatureRequest with the submitted documents. If &#x60;form_fields_per_document&#x60; is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_request [SignatureRequestEditRequest] 
     # @param [Hash] opts the optional parameters
@@ -641,7 +641,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request With Template
-    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_with_template_request [SignatureRequestEditWithTemplateRequest] 
     # @param [Hash] opts the optional parameters
@@ -652,7 +652,7 @@ module Dropbox::Sign
     end
 
     # Edit Signature Request With Template
-    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+    # Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
     # @param signature_request_id [String] The id of the SignatureRequest to edit.
     # @param signature_request_edit_with_template_request [SignatureRequestEditWithTemplateRequest] 
     # @param [Hash] opts the optional parameters

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -391,7 +391,10 @@
 "SignatureRequestSend::USE_PREEXISTING_FIELDS": Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.
 
 "SignatureRequestEdit::SUMMARY": Edit Signature Request
-"SignatureRequestEdit::DESCRIPTION": Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+"SignatureRequestEdit::DESCRIPTION": |-
+  Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
+  
+  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 "SignatureRequestEdit::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to edit.
 
 "SignatureRequestSendWithTemplate::SUMMARY": Send with Template
@@ -425,7 +428,10 @@
 "SignatureRequestSendWithTemplate::TITLE": The title you want to assign to the SignatureRequest.
 
 "SignatureRequestEditWithTemplate::SUMMARY": Edit Signature Request With Template
-"SignatureRequestEditWithTemplate::DESCRIPTION": Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+"SignatureRequestEditWithTemplate::DESCRIPTION": |-
+  Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
+  
+  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
 "SignatureRequestEditWithTemplate::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to edit.
 
 "SignatureRequestUpdate::SUMMARY": Update Signature Request

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -394,7 +394,7 @@
 "SignatureRequestEdit::DESCRIPTION": |-
   Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
   
-  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+  **NOTE:** Edit and resend will not deduct your signature request quota.
 "SignatureRequestEdit::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to edit.
 
 "SignatureRequestSendWithTemplate::SUMMARY": Send with Template
@@ -431,7 +431,7 @@
 "SignatureRequestEditWithTemplate::DESCRIPTION": |-
   Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
   
-  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
+  **NOTE:** Edit and resend will not deduct your signature request quota.
 "SignatureRequestEditWithTemplate::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to edit.
 
 "SignatureRequestUpdate::SUMMARY": Update Signature Request

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -394,7 +394,7 @@
 "SignatureRequestEdit::DESCRIPTION": |-
   Edits and sends a SignatureRequest with the submitted documents. If `form_fields_per_document` is not specified, a signature page will be affixed where all signers will be required to add their signature, signifying their agreement to all contained documents.
   
-  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 "SignatureRequestEdit::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to edit.
 
 "SignatureRequestSendWithTemplate::SUMMARY": Send with Template
@@ -431,7 +431,7 @@
 "SignatureRequestEditWithTemplate::DESCRIPTION": |-
   Edits and sends a SignatureRequest based off of the Template(s) specified with the template_ids parameter.
   
-  **NOTE:** If Dropbox Sign SMS tools is used your quota will be deducted accordingly. [Learn more](https://faq.hellosign.com/hc/en-us/articles/15815316468877-Dropbox-Sign-SMS-tools-add-on).
+  **NOTE:** Edit and resend will not deduct your signature request quota. However, all other quota-related features will be deducted.
 "SignatureRequestEditWithTemplate::SIGNATURE_REQUEST_ID": The id of the SignatureRequest to edit.
 
 "SignatureRequestUpdate::SUMMARY": Update Signature Request


### PR DESCRIPTION
Letting client know that document quota won't be deducted for signature request edits.