### PR TITLE
Update CC email addresses

### DIFF
--- a/examples/json/SignatureRequestCreateEmbeddedRequestDefaultExample.json
+++ b/examples/json/SignatureRequestCreateEmbeddedRequestDefaultExample.json
@@ -16,8 +16,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestCreateEmbeddedRequestGroupedSignersExample.json
+++ b/examples/json/SignatureRequestCreateEmbeddedRequestGroupedSignersExample.json
@@ -34,8 +34,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestCreateEmbeddedResponseExample.json
+++ b/examples/json/SignatureRequestCreateEmbeddedResponseExample.json
@@ -45,8 +45,8 @@
       }
     ],
     "cc_email_addresses": [
-      "lawyer@dropboxsign.com",
-      "lawyer@dropboxsign.com"
+      "lawyer1@dropboxsign.com",
+      "lawyer2@dropboxsign.com"
     ]
   }
 }

--- a/examples/json/SignatureRequestEditEmbeddedRequestDefaultExample.json
+++ b/examples/json/SignatureRequestEditEmbeddedRequestDefaultExample.json
@@ -16,8 +16,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestEditEmbeddedRequestGroupedSignersExample.json
+++ b/examples/json/SignatureRequestEditEmbeddedRequestGroupedSignersExample.json
@@ -34,8 +34,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestEditEmbeddedResponseExample.json
+++ b/examples/json/SignatureRequestEditEmbeddedResponseExample.json
@@ -45,8 +45,8 @@
       }
     ],
     "cc_email_addresses": [
-      "lawyer@dropboxsign.com",
-      "lawyer@dropboxsign.com"
+      "lawyer1@dropboxsign.com",
+      "lawyer2@dropboxsign.com"
     ]
   }
 }

--- a/examples/json/SignatureRequestEditRequestDefaultExample.json
+++ b/examples/json/SignatureRequestEditRequestDefaultExample.json
@@ -15,8 +15,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestEditRequestGroupedSignersExample.json
+++ b/examples/json/SignatureRequestEditRequestGroupedSignersExample.json
@@ -33,8 +33,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestSendRequestDefaultExample.json
+++ b/examples/json/SignatureRequestSendRequestDefaultExample.json
@@ -15,8 +15,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"

--- a/examples/json/SignatureRequestSendRequestGroupedSignersExample.json
+++ b/examples/json/SignatureRequestSendRequestGroupedSignersExample.json
@@ -33,8 +33,8 @@
     }
   ],
   "cc_email_addresses": [
-    "lawyer@dropboxsign.com",
-    "lawyer@dropboxsign.com"
+    "lawyer1@dropboxsign.com",
+    "lawyer2@dropboxsign.com"
   ],
   "file_urls": [
     "https://www.dropbox.com/s/ad9qnhbrjjn64tu/mutual-NDA-example.pdf?dl=1"


### PR DESCRIPTION
Having duplicate email addresses as CCs throws an error when using documentation embedded consoles.