### PR TITLE
Improvements to BulkSendJob response; reduces nullability, sets defaults

### DIFF
--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -9915,11 +9915,15 @@ components:
       x-internal-class: true
     BulkSendJobResponse:
       description: '_t__BulkSendJobResponse::DESCRIPTION'
+      required:
+        - bulk_send_job_id
+        - created_at
+        - is_creator
+        - total
       properties:
         bulk_send_job_id:
           description: '_t__BulkSendJobResponse::BULK_SEND_JOB_ID'
           type: string
-          nullable: true
         total:
           description: '_t__BulkSendJobResponse::TOTAL'
           type: integer

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -10523,11 +10523,15 @@ components:
       x-internal-class: true
     BulkSendJobResponse:
       description: 'Contains information about the BulkSendJob such as when it was created and how many signature requests are queued.'
+      required:
+        - bulk_send_job_id
+        - created_at
+        - is_creator
+        - total
       properties:
         bulk_send_job_id:
           description: 'The id of the BulkSendJob.'
           type: string
-          nullable: true
         total:
           description: 'The total amount of Signature Requests queued for sending.'
           type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10501,11 +10501,15 @@ components:
       x-internal-class: true
     BulkSendJobResponse:
       description: 'Contains information about the BulkSendJob such as when it was created and how many signature requests are queued.'
+      required:
+        - bulk_send_job_id
+        - created_at
+        - is_creator
+        - total
       properties:
         bulk_send_job_id:
           description: 'The id of the BulkSendJob.'
           type: string
-          nullable: true
         total:
           description: 'The total amount of Signature Requests queued for sending.'
           type: integer

--- a/sdks/dotnet/docs/BulkSendJobResponse.md
+++ b/sdks/dotnet/docs/BulkSendJobResponse.md
@@ -5,7 +5,7 @@ Contains information about the BulkSendJob such as when it was created and how m
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**BulkSendJobId** | **string** |  The id of the BulkSendJob.  | [optional] **Total** | **int** |  The total amount of Signature Requests queued for sending.  | [optional] **IsCreator** | **bool** |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  | [optional] **CreatedAt** | **int** |  Time that the BulkSendJob was created.  | [optional] 
+**BulkSendJobId** | **string** |  The id of the BulkSendJob.  | **Total** | **int** |  The total amount of Signature Requests queued for sending.  | **IsCreator** | **bool** |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  | **CreatedAt** | **int** |  Time that the BulkSendJob was created.  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdks/dotnet/src/Dropbox.Sign/Model/BulkSendJobResponse.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Model/BulkSendJobResponse.cs
@@ -41,13 +41,18 @@ namespace Dropbox.Sign.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BulkSendJobResponse" /> class.
         /// </summary>
-        /// <param name="bulkSendJobId">The id of the BulkSendJob..</param>
-        /// <param name="total">The total amount of Signature Requests queued for sending..</param>
-        /// <param name="isCreator">True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member..</param>
-        /// <param name="createdAt">Time that the BulkSendJob was created..</param>
+        /// <param name="bulkSendJobId">The id of the BulkSendJob. (required).</param>
+        /// <param name="total">The total amount of Signature Requests queued for sending. (required).</param>
+        /// <param name="isCreator">True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member. (required).</param>
+        /// <param name="createdAt">Time that the BulkSendJob was created. (required).</param>
         public BulkSendJobResponse(string bulkSendJobId = default(string), int total = default(int), bool isCreator = default(bool), int createdAt = default(int))
         {
 
+            // to ensure "bulkSendJobId" is required (not null)
+            if (bulkSendJobId == null)
+            {
+                throw new ArgumentNullException("bulkSendJobId is a required property for BulkSendJobResponse and cannot be null");
+            }
             this.BulkSendJobId = bulkSendJobId;
             this.Total = total;
             this.IsCreator = isCreator;
@@ -74,28 +79,28 @@ namespace Dropbox.Sign.Model
         /// The id of the BulkSendJob.
         /// </summary>
         /// <value>The id of the BulkSendJob.</value>
-        [DataMember(Name = "bulk_send_job_id", EmitDefaultValue = true)]
+        [DataMember(Name = "bulk_send_job_id", IsRequired = true, EmitDefaultValue = true)]
         public string BulkSendJobId { get; set; }
 
         /// <summary>
         /// The total amount of Signature Requests queued for sending.
         /// </summary>
         /// <value>The total amount of Signature Requests queued for sending.</value>
-        [DataMember(Name = "total", EmitDefaultValue = true)]
+        [DataMember(Name = "total", IsRequired = true, EmitDefaultValue = true)]
         public int Total { get; set; }
 
         /// <summary>
         /// True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.
         /// </summary>
         /// <value>True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.</value>
-        [DataMember(Name = "is_creator", EmitDefaultValue = true)]
+        [DataMember(Name = "is_creator", IsRequired = true, EmitDefaultValue = true)]
         public bool IsCreator { get; set; }
 
         /// <summary>
         /// Time that the BulkSendJob was created.
         /// </summary>
         /// <value>Time that the BulkSendJob was created.</value>
-        [DataMember(Name = "created_at", EmitDefaultValue = true)]
+        [DataMember(Name = "created_at", IsRequired = true, EmitDefaultValue = true)]
         public int CreatedAt { get; set; }
 
         /// <summary>

--- a/sdks/java-v1/docs/BulkSendJobResponse.md
+++ b/sdks/java-v1/docs/BulkSendJobResponse.md
@@ -8,10 +8,10 @@ Contains information about the BulkSendJob such as when it was created and how m
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| `bulkSendJobId` | ```String``` |  The id of the BulkSendJob.  |  |
-| `total` | ```Integer``` |  The total amount of Signature Requests queued for sending.  |  |
-| `isCreator` | ```Boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
-| `createdAt` | ```Integer``` |  Time that the BulkSendJob was created.  |  |
+| `bulkSendJobId`<sup>*_required_</sup> | ```String``` |  The id of the BulkSendJob.  |  |
+| `total`<sup>*_required_</sup> | ```Integer``` |  The total amount of Signature Requests queued for sending.  |  |
+| `isCreator`<sup>*_required_</sup> | ```Boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
+| `createdAt`<sup>*_required_</sup> | ```Integer``` |  Time that the BulkSendJob was created.  |  |
 
 
 

--- a/sdks/java-v1/src/main/java/com/dropbox/sign/model/BulkSendJobResponse.java
+++ b/sdks/java-v1/src/main/java/com/dropbox/sign/model/BulkSendJobResponse.java
@@ -76,14 +76,15 @@ public class BulkSendJobResponse {
      *
      * @return bulkSendJobId
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_BULK_SEND_JOB_ID)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_BULK_SEND_JOB_ID)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public String getBulkSendJobId() {
         return bulkSendJobId;
     }
 
     @JsonProperty(JSON_PROPERTY_BULK_SEND_JOB_ID)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setBulkSendJobId(String bulkSendJobId) {
         this.bulkSendJobId = bulkSendJobId;
     }
@@ -98,14 +99,15 @@ public class BulkSendJobResponse {
      *
      * @return total
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_TOTAL)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_TOTAL)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public Integer getTotal() {
         return total;
     }
 
     @JsonProperty(JSON_PROPERTY_TOTAL)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setTotal(Integer total) {
         this.total = total;
     }
@@ -121,14 +123,15 @@ public class BulkSendJobResponse {
      *
      * @return isCreator
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_IS_CREATOR)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_IS_CREATOR)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public Boolean getIsCreator() {
         return isCreator;
     }
 
     @JsonProperty(JSON_PROPERTY_IS_CREATOR)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setIsCreator(Boolean isCreator) {
         this.isCreator = isCreator;
     }
@@ -143,14 +146,15 @@ public class BulkSendJobResponse {
      *
      * @return createdAt
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_CREATED_AT)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_CREATED_AT)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public Integer getCreatedAt() {
         return createdAt;
     }
 
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setCreatedAt(Integer createdAt) {
         this.createdAt = createdAt;
     }

--- a/sdks/java-v2/docs/BulkSendJobResponse.md
+++ b/sdks/java-v2/docs/BulkSendJobResponse.md
@@ -8,10 +8,10 @@ Contains information about the BulkSendJob such as when it was created and how m
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| `bulkSendJobId` | ```String``` |  The id of the BulkSendJob.  |  |
-| `total` | ```Integer``` |  The total amount of Signature Requests queued for sending.  |  |
-| `isCreator` | ```Boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
-| `createdAt` | ```Integer``` |  Time that the BulkSendJob was created.  |  |
+| `bulkSendJobId`<sup>*_required_</sup> | ```String``` |  The id of the BulkSendJob.  |  |
+| `total`<sup>*_required_</sup> | ```Integer``` |  The total amount of Signature Requests queued for sending.  |  |
+| `isCreator`<sup>*_required_</sup> | ```Boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
+| `createdAt`<sup>*_required_</sup> | ```Integer``` |  Time that the BulkSendJob was created.  |  |
 
 
 

--- a/sdks/java-v2/src/main/java/com/dropbox/sign/model/BulkSendJobResponse.java
+++ b/sdks/java-v2/src/main/java/com/dropbox/sign/model/BulkSendJobResponse.java
@@ -80,9 +80,9 @@ public class BulkSendJobResponse {
    * The id of the BulkSendJob.
    * @return bulkSendJobId
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_BULK_SEND_JOB_ID)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public String getBulkSendJobId() {
     return bulkSendJobId;
@@ -90,7 +90,7 @@ public class BulkSendJobResponse {
 
 
   @JsonProperty(JSON_PROPERTY_BULK_SEND_JOB_ID)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setBulkSendJobId(String bulkSendJobId) {
     this.bulkSendJobId = bulkSendJobId;
   }
@@ -105,9 +105,9 @@ public class BulkSendJobResponse {
    * The total amount of Signature Requests queued for sending.
    * @return total
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TOTAL)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public Integer getTotal() {
     return total;
@@ -115,7 +115,7 @@ public class BulkSendJobResponse {
 
 
   @JsonProperty(JSON_PROPERTY_TOTAL)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setTotal(Integer total) {
     this.total = total;
   }
@@ -130,9 +130,9 @@ public class BulkSendJobResponse {
    * True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.
    * @return isCreator
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_IS_CREATOR)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public Boolean getIsCreator() {
     return isCreator;
@@ -140,7 +140,7 @@ public class BulkSendJobResponse {
 
 
   @JsonProperty(JSON_PROPERTY_IS_CREATOR)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setIsCreator(Boolean isCreator) {
     this.isCreator = isCreator;
   }
@@ -155,9 +155,9 @@ public class BulkSendJobResponse {
    * Time that the BulkSendJob was created.
    * @return createdAt
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public Integer getCreatedAt() {
     return createdAt;
@@ -165,7 +165,7 @@ public class BulkSendJobResponse {
 
 
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setCreatedAt(Integer createdAt) {
     this.createdAt = createdAt;
   }

--- a/sdks/node/docs/model/BulkSendJobResponse.md
+++ b/sdks/node/docs/model/BulkSendJobResponse.md
@@ -6,9 +6,9 @@ Contains information about the BulkSendJob such as when it was created and how m
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `bulkSendJobId` | ```string``` |  The id of the BulkSendJob.  |  |
-| `total` | ```number``` |  The total amount of Signature Requests queued for sending.  |  |
-| `isCreator` | ```boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
-| `createdAt` | ```number``` |  Time that the BulkSendJob was created.  |  |
+| `bulkSendJobId`<sup>*_required_</sup> | ```string``` |  The id of the BulkSendJob.  |  |
+| `total`<sup>*_required_</sup> | ```number``` |  The total amount of Signature Requests queued for sending.  |  |
+| `isCreator`<sup>*_required_</sup> | ```boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
+| `createdAt`<sup>*_required_</sup> | ```number``` |  Time that the BulkSendJob was created.  |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/node/model/bulkSendJobResponse.ts
+++ b/sdks/node/model/bulkSendJobResponse.ts
@@ -31,19 +31,19 @@ export class BulkSendJobResponse {
   /**
    * The id of the BulkSendJob.
    */
-  "bulkSendJobId"?: string | null;
+  "bulkSendJobId": string;
   /**
    * The total amount of Signature Requests queued for sending.
    */
-  "total"?: number;
+  "total": number;
   /**
    * True if you are the owner of this BulkSendJob, false if it\'s been shared with you by a team member.
    */
-  "isCreator"?: boolean;
+  "isCreator": boolean;
   /**
    * Time that the BulkSendJob was created.
    */
-  "createdAt"?: number;
+  "createdAt": number;
 
   static discriminator: string | undefined = undefined;
 

--- a/sdks/node/types/model/bulkSendJobResponse.d.ts
+++ b/sdks/node/types/model/bulkSendJobResponse.d.ts
@@ -1,9 +1,9 @@
 import { AttributeTypeMap } from "./";
 export declare class BulkSendJobResponse {
-    "bulkSendJobId"?: string | null;
-    "total"?: number;
-    "isCreator"?: boolean;
-    "createdAt"?: number;
+    "bulkSendJobId": string;
+    "total": number;
+    "isCreator": boolean;
+    "createdAt": number;
     static discriminator: string | undefined;
     static attributeTypeMap: AttributeTypeMap;
     static getAttributeTypeMap(): AttributeTypeMap;

--- a/sdks/php/docs/Model/BulkSendJobResponse.md
+++ b/sdks/php/docs/Model/BulkSendJobResponse.md
@@ -6,9 +6,9 @@ Contains information about the BulkSendJob such as when it was created and how m
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `bulk_send_job_id` | ```string``` |  The id of the BulkSendJob.  |  |
-| `total` | ```int``` |  The total amount of Signature Requests queued for sending.  |  |
-| `is_creator` | ```bool``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
-| `created_at` | ```int``` |  Time that the BulkSendJob was created.  |  |
+| `bulk_send_job_id`<sup>*_required_</sup> | ```string``` |  The id of the BulkSendJob.  |  |
+| `total`<sup>*_required_</sup> | ```int``` |  The total amount of Signature Requests queued for sending.  |  |
+| `is_creator`<sup>*_required_</sup> | ```bool``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
+| `created_at`<sup>*_required_</sup> | ```int``` |  Time that the BulkSendJob was created.  |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/php/src/Model/BulkSendJobResponse.php
+++ b/sdks/php/src/Model/BulkSendJobResponse.php
@@ -84,7 +84,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      * @var bool[]
      */
     protected static array $openAPINullables = [
-        'bulk_send_job_id' => true,
+        'bulk_send_job_id' => false,
         'total' => false,
         'is_creator' => false,
         'created_at' => false,
@@ -303,7 +303,21 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
      */
     public function listInvalidProperties()
     {
-        return [];
+        $invalidProperties = [];
+
+        if ($this->container['bulk_send_job_id'] === null) {
+            $invalidProperties[] = "'bulk_send_job_id' can't be null";
+        }
+        if ($this->container['total'] === null) {
+            $invalidProperties[] = "'total' can't be null";
+        }
+        if ($this->container['is_creator'] === null) {
+            $invalidProperties[] = "'is_creator' can't be null";
+        }
+        if ($this->container['created_at'] === null) {
+            $invalidProperties[] = "'created_at' can't be null";
+        }
+        return $invalidProperties;
     }
 
     /**
@@ -320,7 +334,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Gets bulk_send_job_id
      *
-     * @return string|null
+     * @return string
      */
     public function getBulkSendJobId()
     {
@@ -330,21 +344,14 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Sets bulk_send_job_id
      *
-     * @param string|null $bulk_send_job_id the id of the BulkSendJob
+     * @param string $bulk_send_job_id the id of the BulkSendJob
      *
      * @return self
      */
-    public function setBulkSendJobId(?string $bulk_send_job_id)
+    public function setBulkSendJobId(string $bulk_send_job_id)
     {
         if (is_null($bulk_send_job_id)) {
-            array_push($this->openAPINullablesSetToNull, 'bulk_send_job_id');
-        } else {
-            $nullablesSetToNull = $this->getOpenAPINullablesSetToNull();
-            $index = array_search('bulk_send_job_id', $nullablesSetToNull);
-            if ($index !== false) {
-                unset($nullablesSetToNull[$index]);
-                $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
-            }
+            throw new InvalidArgumentException('non-nullable bulk_send_job_id cannot be null');
         }
         $this->container['bulk_send_job_id'] = $bulk_send_job_id;
 
@@ -354,7 +361,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Gets total
      *
-     * @return int|null
+     * @return int
      */
     public function getTotal()
     {
@@ -364,11 +371,11 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Sets total
      *
-     * @param int|null $total the total amount of Signature Requests queued for sending
+     * @param int $total the total amount of Signature Requests queued for sending
      *
      * @return self
      */
-    public function setTotal(?int $total)
+    public function setTotal(int $total)
     {
         if (is_null($total)) {
             throw new InvalidArgumentException('non-nullable total cannot be null');
@@ -381,7 +388,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Gets is_creator
      *
-     * @return bool|null
+     * @return bool
      */
     public function getIsCreator()
     {
@@ -391,11 +398,11 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Sets is_creator
      *
-     * @param bool|null $is_creator true if you are the owner of this BulkSendJob, false if it's been shared with you by a team member
+     * @param bool $is_creator true if you are the owner of this BulkSendJob, false if it's been shared with you by a team member
      *
      * @return self
      */
-    public function setIsCreator(?bool $is_creator)
+    public function setIsCreator(bool $is_creator)
     {
         if (is_null($is_creator)) {
             throw new InvalidArgumentException('non-nullable is_creator cannot be null');
@@ -408,7 +415,7 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Gets created_at
      *
-     * @return int|null
+     * @return int
      */
     public function getCreatedAt()
     {
@@ -418,11 +425,11 @@ class BulkSendJobResponse implements ModelInterface, ArrayAccess, JsonSerializab
     /**
      * Sets created_at
      *
-     * @param int|null $created_at time that the BulkSendJob was created
+     * @param int $created_at time that the BulkSendJob was created
      *
      * @return self
      */
-    public function setCreatedAt(?int $created_at)
+    public function setCreatedAt(int $created_at)
     {
         if (is_null($created_at)) {
             throw new InvalidArgumentException('non-nullable created_at cannot be null');

--- a/sdks/python/docs/BulkSendJobResponse.md
+++ b/sdks/python/docs/BulkSendJobResponse.md
@@ -5,10 +5,10 @@ Contains information about the BulkSendJob such as when it was created and how m
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `bulk_send_job_id` | ```str``` |  The id of the BulkSendJob.  |  |
-| `total` | ```int``` |  The total amount of Signature Requests queued for sending.  |  |
-| `is_creator` | ```bool``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
-| `created_at` | ```int``` |  Time that the BulkSendJob was created.  |  |
+| `bulk_send_job_id`<sup>*_required_</sup> | ```str``` |  The id of the BulkSendJob.  |  |
+| `total`<sup>*_required_</sup> | ```int``` |  The total amount of Signature Requests queued for sending.  |  |
+| `is_creator`<sup>*_required_</sup> | ```bool``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
+| `created_at`<sup>*_required_</sup> | ```int``` |  Time that the BulkSendJob was created.  |  |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdks/python/dropbox_sign/models/bulk_send_job_response.py
+++ b/sdks/python/dropbox_sign/models/bulk_send_job_response.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List
 from typing import Optional, Set, Tuple
 from typing_extensions import Self
 import io
@@ -32,20 +32,14 @@ class BulkSendJobResponse(BaseModel):
     Contains information about the BulkSendJob such as when it was created and how many signature requests are queued.
     """  # noqa: E501
 
-    bulk_send_job_id: Optional[StrictStr] = Field(
-        default=None, description="The id of the BulkSendJob."
+    bulk_send_job_id: StrictStr = Field(description="The id of the BulkSendJob.")
+    total: StrictInt = Field(
+        description="The total amount of Signature Requests queued for sending."
     )
-    total: Optional[StrictInt] = Field(
-        default=None,
-        description="The total amount of Signature Requests queued for sending.",
+    is_creator: StrictBool = Field(
+        description="True if you are the owner of this BulkSendJob, false if it's been shared with you by a team member."
     )
-    is_creator: Optional[StrictBool] = Field(
-        default=None,
-        description="True if you are the owner of this BulkSendJob, false if it's been shared with you by a team member.",
-    )
-    created_at: Optional[StrictInt] = Field(
-        default=None, description="Time that the BulkSendJob was created."
-    )
+    created_at: StrictInt = Field(description="Time that the BulkSendJob was created.")
     __properties: ClassVar[List[str]] = [
         "bulk_send_job_id",
         "total",

--- a/sdks/ruby/docs/BulkSendJobResponse.md
+++ b/sdks/ruby/docs/BulkSendJobResponse.md
@@ -6,8 +6,8 @@ Contains information about the BulkSendJob such as when it was created and how m
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| `bulk_send_job_id` | ```String``` |  The id of the BulkSendJob.  |  |
-| `total` | ```Integer``` |  The total amount of Signature Requests queued for sending.  |  |
-| `is_creator` | ```Boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
-| `created_at` | ```Integer``` |  Time that the BulkSendJob was created.  |  |
+| `bulk_send_job_id`<sup>*_required_</sup> | ```String``` |  The id of the BulkSendJob.  |  |
+| `total`<sup>*_required_</sup> | ```Integer``` |  The total amount of Signature Requests queued for sending.  |  |
+| `is_creator`<sup>*_required_</sup> | ```Boolean``` |  True if you are the owner of this BulkSendJob, false if it&#39;s been shared with you by a team member.  |  |
+| `created_at`<sup>*_required_</sup> | ```Integer``` |  Time that the BulkSendJob was created.  |  |
 

--- a/sdks/ruby/lib/dropbox-sign/models/bulk_send_job_response.rb
+++ b/sdks/ruby/lib/dropbox-sign/models/bulk_send_job_response.rb
@@ -20,7 +20,7 @@ module Dropbox::Sign
   # Contains information about the BulkSendJob such as when it was created and how many signature requests are queued.
   class BulkSendJobResponse
     # The id of the BulkSendJob.
-    # @return [String, nil]
+    # @return [String]
     attr_accessor :bulk_send_job_id
 
     # The total amount of Signature Requests queued for sending.
@@ -63,7 +63,6 @@ module Dropbox::Sign
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
-        :'bulk_send_job_id',
       ])
     end
 
@@ -128,12 +127,32 @@ module Dropbox::Sign
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
+      if @bulk_send_job_id.nil?
+        invalid_properties.push('invalid value for "bulk_send_job_id", bulk_send_job_id cannot be nil.')
+      end
+
+      if @total.nil?
+        invalid_properties.push('invalid value for "total", total cannot be nil.')
+      end
+
+      if @is_creator.nil?
+        invalid_properties.push('invalid value for "is_creator", is_creator cannot be nil.')
+      end
+
+      if @created_at.nil?
+        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
+      end
+
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
+      return false if @bulk_send_job_id.nil?
+      return false if @total.nil?
+      return false if @is_creator.nil?
+      return false if @created_at.nil?
       true
     end
 


### PR DESCRIPTION
`BulkSendJobResponse` updated. The following properties are now non-nullable:

* `bulk_send_job_id`
* `created_at`
* `is_creator`
* `total`