### PR TITLE
Improvements to FaxLine response; reduces nullability

### DIFF
--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -10018,6 +10018,11 @@ components:
           type: string
       type: object
     FaxLineResponseFaxLine:
+      required:
+        - accounts
+        - created_at
+        - number
+        - updated_at
       properties:
         number:
           description: '_t__FaxLineResponseFaxLine::NUMBER'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -10626,6 +10626,11 @@ components:
           type: string
       type: object
     FaxLineResponseFaxLine:
+      required:
+        - accounts
+        - created_at
+        - number
+        - updated_at
       properties:
         number:
           description: Number

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10604,6 +10604,11 @@ components:
           type: string
       type: object
     FaxLineResponseFaxLine:
+      required:
+        - accounts
+        - created_at
+        - number
+        - updated_at
       properties:
         number:
           description: Number

--- a/sdks/dotnet/docs/FaxLineResponseFaxLine.md
+++ b/sdks/dotnet/docs/FaxLineResponseFaxLine.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Number** | **string** |  Number  | [optional] **CreatedAt** | **int** |  Created at  | [optional] **UpdatedAt** | **int** |  Updated at  | [optional] **Accounts** | [**List&lt;AccountResponse&gt;**](AccountResponse.md) |    | [optional] 
+**Number** | **string** |  Number  | **CreatedAt** | **int** |  Created at  | **UpdatedAt** | **int** |  Updated at  | **Accounts** | [**List&lt;AccountResponse&gt;**](AccountResponse.md) |    | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdks/dotnet/src/Dropbox.Sign/Model/FaxLineResponseFaxLine.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Model/FaxLineResponseFaxLine.cs
@@ -41,16 +41,26 @@ namespace Dropbox.Sign.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="FaxLineResponseFaxLine" /> class.
         /// </summary>
-        /// <param name="number">Number.</param>
-        /// <param name="createdAt">Created at.</param>
-        /// <param name="updatedAt">Updated at.</param>
-        /// <param name="accounts">accounts.</param>
+        /// <param name="number">Number (required).</param>
+        /// <param name="createdAt">Created at (required).</param>
+        /// <param name="updatedAt">Updated at (required).</param>
+        /// <param name="accounts">accounts (required).</param>
         public FaxLineResponseFaxLine(string number = default(string), int createdAt = default(int), int updatedAt = default(int), List<AccountResponse> accounts = default(List<AccountResponse>))
         {
 
+            // to ensure "number" is required (not null)
+            if (number == null)
+            {
+                throw new ArgumentNullException("number is a required property for FaxLineResponseFaxLine and cannot be null");
+            }
             this.Number = number;
             this.CreatedAt = createdAt;
             this.UpdatedAt = updatedAt;
+            // to ensure "accounts" is required (not null)
+            if (accounts == null)
+            {
+                throw new ArgumentNullException("accounts is a required property for FaxLineResponseFaxLine and cannot be null");
+            }
             this.Accounts = accounts;
         }
 
@@ -74,27 +84,27 @@ namespace Dropbox.Sign.Model
         /// Number
         /// </summary>
         /// <value>Number</value>
-        [DataMember(Name = "number", EmitDefaultValue = true)]
+        [DataMember(Name = "number", IsRequired = true, EmitDefaultValue = true)]
         public string Number { get; set; }
 
         /// <summary>
         /// Created at
         /// </summary>
         /// <value>Created at</value>
-        [DataMember(Name = "created_at", EmitDefaultValue = true)]
+        [DataMember(Name = "created_at", IsRequired = true, EmitDefaultValue = true)]
         public int CreatedAt { get; set; }
 
         /// <summary>
         /// Updated at
         /// </summary>
         /// <value>Updated at</value>
-        [DataMember(Name = "updated_at", EmitDefaultValue = true)]
+        [DataMember(Name = "updated_at", IsRequired = true, EmitDefaultValue = true)]
         public int UpdatedAt { get; set; }
 
         /// <summary>
         /// Gets or Sets Accounts
         /// </summary>
-        [DataMember(Name = "accounts", EmitDefaultValue = true)]
+        [DataMember(Name = "accounts", IsRequired = true, EmitDefaultValue = true)]
         public List<AccountResponse> Accounts { get; set; }
 
         /// <summary>

--- a/sdks/java-v1/docs/FaxLineResponseFaxLine.md
+++ b/sdks/java-v1/docs/FaxLineResponseFaxLine.md
@@ -8,10 +8,10 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| `number` | ```String``` |  Number  |  |
-| `createdAt` | ```Integer``` |  Created at  |  |
-| `updatedAt` | ```Integer``` |  Updated at  |  |
-| `accounts` | [```List<AccountResponse>```](AccountResponse.md) |    |  |
+| `number`<sup>*_required_</sup> | ```String``` |  Number  |  |
+| `createdAt`<sup>*_required_</sup> | ```Integer``` |  Created at  |  |
+| `updatedAt`<sup>*_required_</sup> | ```Integer``` |  Updated at  |  |
+| `accounts`<sup>*_required_</sup> | [```List<AccountResponse>```](AccountResponse.md) |    |  |
 
 
 

--- a/sdks/java-v1/src/main/java/com/dropbox/sign/model/FaxLineResponseFaxLine.java
+++ b/sdks/java-v1/src/main/java/com/dropbox/sign/model/FaxLineResponseFaxLine.java
@@ -47,7 +47,7 @@ public class FaxLineResponseFaxLine {
     private Integer updatedAt;
 
     public static final String JSON_PROPERTY_ACCOUNTS = "accounts";
-    private List<AccountResponse> accounts = null;
+    private List<AccountResponse> accounts = new ArrayList<>();
 
     public FaxLineResponseFaxLine() {}
 
@@ -76,14 +76,15 @@ public class FaxLineResponseFaxLine {
      *
      * @return number
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_NUMBER)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_NUMBER)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public String getNumber() {
         return number;
     }
 
     @JsonProperty(JSON_PROPERTY_NUMBER)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setNumber(String number) {
         this.number = number;
     }
@@ -98,14 +99,15 @@ public class FaxLineResponseFaxLine {
      *
      * @return createdAt
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_CREATED_AT)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_CREATED_AT)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public Integer getCreatedAt() {
         return createdAt;
     }
 
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setCreatedAt(Integer createdAt) {
         this.createdAt = createdAt;
     }
@@ -120,14 +122,15 @@ public class FaxLineResponseFaxLine {
      *
      * @return updatedAt
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_UPDATED_AT)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_UPDATED_AT)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public Integer getUpdatedAt() {
         return updatedAt;
     }
 
     @JsonProperty(JSON_PROPERTY_UPDATED_AT)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setUpdatedAt(Integer updatedAt) {
         this.updatedAt = updatedAt;
     }
@@ -150,14 +153,15 @@ public class FaxLineResponseFaxLine {
      *
      * @return accounts
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_ACCOUNTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public List<AccountResponse> getAccounts() {
         return accounts;
     }
 
     @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setAccounts(List<AccountResponse> accounts) {
         this.accounts = accounts;
     }

--- a/sdks/java-v2/docs/FaxLineResponseFaxLine.md
+++ b/sdks/java-v2/docs/FaxLineResponseFaxLine.md
@@ -8,10 +8,10 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| `number` | ```String``` |  Number  |  |
-| `createdAt` | ```Integer``` |  Created at  |  |
-| `updatedAt` | ```Integer``` |  Updated at  |  |
-| `accounts` | [```List<AccountResponse>```](AccountResponse.md) |    |  |
+| `number`<sup>*_required_</sup> | ```String``` |  Number  |  |
+| `createdAt`<sup>*_required_</sup> | ```Integer``` |  Created at  |  |
+| `updatedAt`<sup>*_required_</sup> | ```Integer``` |  Updated at  |  |
+| `accounts`<sup>*_required_</sup> | [```List<AccountResponse>```](AccountResponse.md) |    |  |
 
 
 

--- a/sdks/java-v2/src/main/java/com/dropbox/sign/model/FaxLineResponseFaxLine.java
+++ b/sdks/java-v2/src/main/java/com/dropbox/sign/model/FaxLineResponseFaxLine.java
@@ -54,7 +54,7 @@ public class FaxLineResponseFaxLine {
   private Integer updatedAt;
 
   public static final String JSON_PROPERTY_ACCOUNTS = "accounts";
-  private List<AccountResponse> accounts = null;
+  private List<AccountResponse> accounts = new ArrayList<>();
 
   public FaxLineResponseFaxLine() { 
   }
@@ -83,9 +83,9 @@ public class FaxLineResponseFaxLine {
    * Number
    * @return number
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NUMBER)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public String getNumber() {
     return number;
@@ -93,7 +93,7 @@ public class FaxLineResponseFaxLine {
 
 
   @JsonProperty(JSON_PROPERTY_NUMBER)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setNumber(String number) {
     this.number = number;
   }
@@ -108,9 +108,9 @@ public class FaxLineResponseFaxLine {
    * Created at
    * @return createdAt
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public Integer getCreatedAt() {
     return createdAt;
@@ -118,7 +118,7 @@ public class FaxLineResponseFaxLine {
 
 
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setCreatedAt(Integer createdAt) {
     this.createdAt = createdAt;
   }
@@ -133,9 +133,9 @@ public class FaxLineResponseFaxLine {
    * Updated at
    * @return updatedAt
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public Integer getUpdatedAt() {
     return updatedAt;
@@ -143,7 +143,7 @@ public class FaxLineResponseFaxLine {
 
 
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setUpdatedAt(Integer updatedAt) {
     this.updatedAt = updatedAt;
   }
@@ -166,9 +166,9 @@ public class FaxLineResponseFaxLine {
    * Get accounts
    * @return accounts
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public List<AccountResponse> getAccounts() {
     return accounts;
@@ -176,7 +176,7 @@ public class FaxLineResponseFaxLine {
 
 
   @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setAccounts(List<AccountResponse> accounts) {
     this.accounts = accounts;
   }

--- a/sdks/node/docs/model/FaxLineResponseFaxLine.md
+++ b/sdks/node/docs/model/FaxLineResponseFaxLine.md
@@ -6,9 +6,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `number` | ```string``` |  Number  |  |
-| `createdAt` | ```number``` |  Created at  |  |
-| `updatedAt` | ```number``` |  Updated at  |  |
-| `accounts` | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
+| `number`<sup>*_required_</sup> | ```string``` |  Number  |  |
+| `createdAt`<sup>*_required_</sup> | ```number``` |  Created at  |  |
+| `updatedAt`<sup>*_required_</sup> | ```number``` |  Updated at  |  |
+| `accounts`<sup>*_required_</sup> | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/node/model/faxLineResponseFaxLine.ts
+++ b/sdks/node/model/faxLineResponseFaxLine.ts
@@ -29,16 +29,16 @@ export class FaxLineResponseFaxLine {
   /**
    * Number
    */
-  "number"?: string;
+  "number": string;
   /**
    * Created at
    */
-  "createdAt"?: number;
+  "createdAt": number;
   /**
    * Updated at
    */
-  "updatedAt"?: number;
-  "accounts"?: Array<AccountResponse>;
+  "updatedAt": number;
+  "accounts": Array<AccountResponse>;
 
   static discriminator: string | undefined = undefined;
 

--- a/sdks/node/types/model/faxLineResponseFaxLine.d.ts
+++ b/sdks/node/types/model/faxLineResponseFaxLine.d.ts
@@ -1,10 +1,10 @@
 import { AttributeTypeMap } from "./";
 import { AccountResponse } from "./accountResponse";
 export declare class FaxLineResponseFaxLine {
-    "number"?: string;
-    "createdAt"?: number;
-    "updatedAt"?: number;
-    "accounts"?: Array<AccountResponse>;
+    "number": string;
+    "createdAt": number;
+    "updatedAt": number;
+    "accounts": Array<AccountResponse>;
     static discriminator: string | undefined;
     static attributeTypeMap: AttributeTypeMap;
     static getAttributeTypeMap(): AttributeTypeMap;

--- a/sdks/php/docs/Model/FaxLineResponseFaxLine.md
+++ b/sdks/php/docs/Model/FaxLineResponseFaxLine.md
@@ -6,9 +6,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `number` | ```string``` |  Number  |  |
-| `created_at` | ```int``` |  Created at  |  |
-| `updated_at` | ```int``` |  Updated at  |  |
-| `accounts` | [```\Dropbox\Sign\Model\AccountResponse[]```](AccountResponse.md) |    |  |
+| `number`<sup>*_required_</sup> | ```string``` |  Number  |  |
+| `created_at`<sup>*_required_</sup> | ```int``` |  Created at  |  |
+| `updated_at`<sup>*_required_</sup> | ```int``` |  Updated at  |  |
+| `accounts`<sup>*_required_</sup> | [```\Dropbox\Sign\Model\AccountResponse[]```](AccountResponse.md) |    |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/php/src/Model/FaxLineResponseFaxLine.php
+++ b/sdks/php/src/Model/FaxLineResponseFaxLine.php
@@ -302,7 +302,21 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
      */
     public function listInvalidProperties()
     {
-        return [];
+        $invalidProperties = [];
+
+        if ($this->container['number'] === null) {
+            $invalidProperties[] = "'number' can't be null";
+        }
+        if ($this->container['created_at'] === null) {
+            $invalidProperties[] = "'created_at' can't be null";
+        }
+        if ($this->container['updated_at'] === null) {
+            $invalidProperties[] = "'updated_at' can't be null";
+        }
+        if ($this->container['accounts'] === null) {
+            $invalidProperties[] = "'accounts' can't be null";
+        }
+        return $invalidProperties;
     }
 
     /**
@@ -319,7 +333,7 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Gets number
      *
-     * @return string|null
+     * @return string
      */
     public function getNumber()
     {
@@ -329,11 +343,11 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Sets number
      *
-     * @param string|null $number Number
+     * @param string $number Number
      *
      * @return self
      */
-    public function setNumber(?string $number)
+    public function setNumber(string $number)
     {
         if (is_null($number)) {
             throw new InvalidArgumentException('non-nullable number cannot be null');
@@ -346,7 +360,7 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Gets created_at
      *
-     * @return int|null
+     * @return int
      */
     public function getCreatedAt()
     {
@@ -356,11 +370,11 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Sets created_at
      *
-     * @param int|null $created_at Created at
+     * @param int $created_at Created at
      *
      * @return self
      */
-    public function setCreatedAt(?int $created_at)
+    public function setCreatedAt(int $created_at)
     {
         if (is_null($created_at)) {
             throw new InvalidArgumentException('non-nullable created_at cannot be null');
@@ -373,7 +387,7 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Gets updated_at
      *
-     * @return int|null
+     * @return int
      */
     public function getUpdatedAt()
     {
@@ -383,11 +397,11 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Sets updated_at
      *
-     * @param int|null $updated_at Updated at
+     * @param int $updated_at Updated at
      *
      * @return self
      */
-    public function setUpdatedAt(?int $updated_at)
+    public function setUpdatedAt(int $updated_at)
     {
         if (is_null($updated_at)) {
             throw new InvalidArgumentException('non-nullable updated_at cannot be null');
@@ -400,7 +414,7 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Gets accounts
      *
-     * @return AccountResponse[]|null
+     * @return AccountResponse[]
      */
     public function getAccounts()
     {
@@ -410,11 +424,11 @@ class FaxLineResponseFaxLine implements ModelInterface, ArrayAccess, JsonSeriali
     /**
      * Sets accounts
      *
-     * @param AccountResponse[]|null $accounts accounts
+     * @param AccountResponse[] $accounts accounts
      *
      * @return self
      */
-    public function setAccounts(?array $accounts)
+    public function setAccounts(array $accounts)
     {
         if (is_null($accounts)) {
             throw new InvalidArgumentException('non-nullable accounts cannot be null');

--- a/sdks/python/docs/FaxLineResponseFaxLine.md
+++ b/sdks/python/docs/FaxLineResponseFaxLine.md
@@ -5,10 +5,10 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `number` | ```str``` |  Number  |  |
-| `created_at` | ```int``` |  Created at  |  |
-| `updated_at` | ```int``` |  Updated at  |  |
-| `accounts` | [```List[AccountResponse]```](AccountResponse.md) |    |  |
+| `number`<sup>*_required_</sup> | ```str``` |  Number  |  |
+| `created_at`<sup>*_required_</sup> | ```int``` |  Created at  |  |
+| `updated_at`<sup>*_required_</sup> | ```int``` |  Updated at  |  |
+| `accounts`<sup>*_required_</sup> | [```List[AccountResponse]```](AccountResponse.md) |    |  |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdks/python/dropbox_sign/models/fax_line_response_fax_line.py
+++ b/sdks/python/dropbox_sign/models/fax_line_response_fax_line.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List
 from dropbox_sign.models.account_response import AccountResponse
 from typing import Optional, Set, Tuple
 from typing_extensions import Self
@@ -33,10 +33,10 @@ class FaxLineResponseFaxLine(BaseModel):
     FaxLineResponseFaxLine
     """  # noqa: E501
 
-    number: Optional[StrictStr] = Field(default=None, description="Number")
-    created_at: Optional[StrictInt] = Field(default=None, description="Created at")
-    updated_at: Optional[StrictInt] = Field(default=None, description="Updated at")
-    accounts: Optional[List[AccountResponse]] = None
+    number: StrictStr = Field(description="Number")
+    created_at: StrictInt = Field(description="Created at")
+    updated_at: StrictInt = Field(description="Updated at")
+    accounts: List[AccountResponse]
     __properties: ClassVar[List[str]] = [
         "number",
         "created_at",

--- a/sdks/ruby/docs/FaxLineResponseFaxLine.md
+++ b/sdks/ruby/docs/FaxLineResponseFaxLine.md
@@ -6,8 +6,8 @@
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| `number` | ```String``` |  Number  |  |
-| `created_at` | ```Integer``` |  Created at  |  |
-| `updated_at` | ```Integer``` |  Updated at  |  |
-| `accounts` | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
+| `number`<sup>*_required_</sup> | ```String``` |  Number  |  |
+| `created_at`<sup>*_required_</sup> | ```Integer``` |  Created at  |  |
+| `updated_at`<sup>*_required_</sup> | ```Integer``` |  Updated at  |  |
+| `accounts`<sup>*_required_</sup> | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
 

--- a/sdks/ruby/lib/dropbox-sign/models/fax_line_response_fax_line.rb
+++ b/sdks/ruby/lib/dropbox-sign/models/fax_line_response_fax_line.rb
@@ -127,12 +127,32 @@ module Dropbox::Sign
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
+      if @number.nil?
+        invalid_properties.push('invalid value for "number", number cannot be nil.')
+      end
+
+      if @created_at.nil?
+        invalid_properties.push('invalid value for "created_at", created_at cannot be nil.')
+      end
+
+      if @updated_at.nil?
+        invalid_properties.push('invalid value for "updated_at", updated_at cannot be nil.')
+      end
+
+      if @accounts.nil?
+        invalid_properties.push('invalid value for "accounts", accounts cannot be nil.')
+      end
+
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
+      return false if @number.nil?
+      return false if @created_at.nil?
+      return false if @updated_at.nil?
+      return false if @accounts.nil?
       true
     end
 


### PR DESCRIPTION
`FaxLineResponse` updated. The following properties are now non-nullable:

* `accounts `
* `created_at `
* `number `
* `updated_at `