### PR TITLE
Improvements to Team response; reduces nullability

### DIFF
--- a/examples/json/TeamAddMemberResponseExample.json
+++ b/examples/json/TeamAddMemberResponseExample.json
@@ -30,6 +30,10 @@
         }
       }
     ],
-    "invited_emails": []
+    "invited_emails": [
+      "invite_1@example.com",
+      "invite_2@example.com",
+      "invite_3@example.com"
+    ]
   }
 }

--- a/examples/json/TeamGetResponseExample.json
+++ b/examples/json/TeamGetResponseExample.json
@@ -29,7 +29,24 @@
         "role_code": "m"
       }
     ],
-    "invited_accounts": [],
-    "invited_emails": []
+    "invited_accounts": [
+      {
+        "account_id": "8e239b5a50eac117fdd9a0e2359620aa57cb2463",
+        "email_address": "george@hellofax.com",
+        "is_locked": false,
+        "is_paid_hs": false,
+        "is_paid_hf": false,
+        "quotas": {
+          "templates_left": 0,
+          "documents_left": 3,
+          "api_signature_requests_left": 0
+        }
+      }
+    ],
+    "invited_emails": [
+      "invite_1@example.com",
+      "invite_2@example.com",
+      "invite_3@example.com"
+    ]
   }
 }

--- a/examples/json/TeamRemoveMemberResponseExample.json
+++ b/examples/json/TeamRemoveMemberResponseExample.json
@@ -16,7 +16,24 @@
         "role_code": "a"
       }
     ],
-    "invited_accounts": [],
-    "invited_emails": []
+    "invited_accounts": [
+      {
+        "account_id": "8e239b5a50eac117fdd9a0e2359620aa57cb2463",
+        "email_address": "george@hellofax.com",
+        "is_locked": false,
+        "is_paid_hs": false,
+        "is_paid_hf": false,
+        "quotas": {
+          "templates_left": 0,
+          "documents_left": 3,
+          "api_signature_requests_left": 0
+        }
+      }
+    ],
+    "invited_emails": [
+      "invite_1@example.com",
+      "invite_2@example.com",
+      "invite_3@example.com"
+    ]
   }
 }

--- a/examples/json/TeamUpdateResponseExample.json
+++ b/examples/json/TeamUpdateResponseExample.json
@@ -16,7 +16,24 @@
         "role_code": "a"
       }
     ],
-    "invited_accounts": [],
-    "invited_emails": []
+    "invited_accounts": [
+      {
+        "account_id": "8e239b5a50eac117fdd9a0e2359620aa57cb2463",
+        "email_address": "george@hellofax.com",
+        "is_locked": false,
+        "is_paid_hs": false,
+        "is_paid_hf": false,
+        "quotas": {
+          "templates_left": 0,
+          "documents_left": 3,
+          "api_signature_requests_left": 0
+        }
+      }
+    ],
+    "invited_emails": [
+      "invite_1@example.com",
+      "invite_2@example.com",
+      "invite_3@example.com"
+    ]
   }
 }

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -10532,6 +10532,11 @@ components:
       x-internal-class: true
     TeamResponse:
       description: '_t__TeamResponse::DESCRIPTION'
+      required:
+        - name
+        - accounts
+        - invited_accounts
+        - invited_emails
       properties:
         name:
           description: '_t__Team::NAME'

--- a/openapi-sdk.yaml
+++ b/openapi-sdk.yaml
@@ -11148,6 +11148,11 @@ components:
       x-internal-class: true
     TeamResponse:
       description: 'Contains information about your team and its members'
+      required:
+        - name
+        - accounts
+        - invited_accounts
+        - invited_emails
       properties:
         name:
           description: 'The name of your Team'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11126,6 +11126,11 @@ components:
       x-internal-class: true
     TeamResponse:
       description: 'Contains information about your team and its members'
+      required:
+        - name
+        - accounts
+        - invited_accounts
+        - invited_emails
       properties:
         name:
           description: 'The name of your Team'

--- a/sdks/dotnet/docs/TeamResponse.md
+++ b/sdks/dotnet/docs/TeamResponse.md
@@ -5,7 +5,7 @@ Contains information about your team and its members
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  The name of your Team  | [optional] **Accounts** | [**List&lt;AccountResponse&gt;**](AccountResponse.md) |    | [optional] **InvitedAccounts** | [**List&lt;AccountResponse&gt;**](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  | [optional] **InvitedEmails** | **List&lt;string&gt;** |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  | [optional] 
+**Name** | **string** |  The name of your Team  | **Accounts** | [**List&lt;AccountResponse&gt;**](AccountResponse.md) |    | **InvitedAccounts** | [**List&lt;AccountResponse&gt;**](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  | **InvitedEmails** | **List&lt;string&gt;** |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdks/dotnet/src/Dropbox.Sign/Model/TeamResponse.cs
+++ b/sdks/dotnet/src/Dropbox.Sign/Model/TeamResponse.cs
@@ -41,16 +41,36 @@ namespace Dropbox.Sign.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="TeamResponse" /> class.
         /// </summary>
-        /// <param name="name">The name of your Team.</param>
-        /// <param name="accounts">accounts.</param>
-        /// <param name="invitedAccounts">A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in &#x60;GET /account&#x60;..</param>
-        /// <param name="invitedEmails">A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account..</param>
+        /// <param name="name">The name of your Team (required).</param>
+        /// <param name="accounts">accounts (required).</param>
+        /// <param name="invitedAccounts">A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in &#x60;GET /account&#x60;. (required).</param>
+        /// <param name="invitedEmails">A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account. (required).</param>
         public TeamResponse(string name = default(string), List<AccountResponse> accounts = default(List<AccountResponse>), List<AccountResponse> invitedAccounts = default(List<AccountResponse>), List<string> invitedEmails = default(List<string>))
         {
 
+            // to ensure "name" is required (not null)
+            if (name == null)
+            {
+                throw new ArgumentNullException("name is a required property for TeamResponse and cannot be null");
+            }
             this.Name = name;
+            // to ensure "accounts" is required (not null)
+            if (accounts == null)
+            {
+                throw new ArgumentNullException("accounts is a required property for TeamResponse and cannot be null");
+            }
             this.Accounts = accounts;
+            // to ensure "invitedAccounts" is required (not null)
+            if (invitedAccounts == null)
+            {
+                throw new ArgumentNullException("invitedAccounts is a required property for TeamResponse and cannot be null");
+            }
             this.InvitedAccounts = invitedAccounts;
+            // to ensure "invitedEmails" is required (not null)
+            if (invitedEmails == null)
+            {
+                throw new ArgumentNullException("invitedEmails is a required property for TeamResponse and cannot be null");
+            }
             this.InvitedEmails = invitedEmails;
         }
 
@@ -74,27 +94,27 @@ namespace Dropbox.Sign.Model
         /// The name of your Team
         /// </summary>
         /// <value>The name of your Team</value>
-        [DataMember(Name = "name", EmitDefaultValue = true)]
+        [DataMember(Name = "name", IsRequired = true, EmitDefaultValue = true)]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or Sets Accounts
         /// </summary>
-        [DataMember(Name = "accounts", EmitDefaultValue = true)]
+        [DataMember(Name = "accounts", IsRequired = true, EmitDefaultValue = true)]
         public List<AccountResponse> Accounts { get; set; }
 
         /// <summary>
         /// A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in &#x60;GET /account&#x60;.
         /// </summary>
         /// <value>A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in &#x60;GET /account&#x60;.</value>
-        [DataMember(Name = "invited_accounts", EmitDefaultValue = true)]
+        [DataMember(Name = "invited_accounts", IsRequired = true, EmitDefaultValue = true)]
         public List<AccountResponse> InvitedAccounts { get; set; }
 
         /// <summary>
         /// A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.
         /// </summary>
         /// <value>A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.</value>
-        [DataMember(Name = "invited_emails", EmitDefaultValue = true)]
+        [DataMember(Name = "invited_emails", IsRequired = true, EmitDefaultValue = true)]
         public List<string> InvitedEmails { get; set; }
 
         /// <summary>

--- a/sdks/java-v1/docs/TeamResponse.md
+++ b/sdks/java-v1/docs/TeamResponse.md
@@ -8,10 +8,10 @@ Contains information about your team and its members
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| `name` | ```String``` |  The name of your Team  |  |
-| `accounts` | [```List<AccountResponse>```](AccountResponse.md) |    |  |
-| `invitedAccounts` | [```List<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
-| `invitedEmails` | ```List<String>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
+| `name`<sup>*_required_</sup> | ```String``` |  The name of your Team  |  |
+| `accounts`<sup>*_required_</sup> | [```List<AccountResponse>```](AccountResponse.md) |    |  |
+| `invitedAccounts`<sup>*_required_</sup> | [```List<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
+| `invitedEmails`<sup>*_required_</sup> | ```List<String>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
 
 
 

--- a/sdks/java-v1/src/main/java/com/dropbox/sign/model/TeamResponse.java
+++ b/sdks/java-v1/src/main/java/com/dropbox/sign/model/TeamResponse.java
@@ -41,13 +41,13 @@ public class TeamResponse {
     private String name;
 
     public static final String JSON_PROPERTY_ACCOUNTS = "accounts";
-    private List<AccountResponse> accounts = null;
+    private List<AccountResponse> accounts = new ArrayList<>();
 
     public static final String JSON_PROPERTY_INVITED_ACCOUNTS = "invited_accounts";
-    private List<AccountResponse> invitedAccounts = null;
+    private List<AccountResponse> invitedAccounts = new ArrayList<>();
 
     public static final String JSON_PROPERTY_INVITED_EMAILS = "invited_emails";
-    private List<String> invitedEmails = null;
+    private List<String> invitedEmails = new ArrayList<>();
 
     public TeamResponse() {}
 
@@ -75,14 +75,15 @@ public class TeamResponse {
      *
      * @return name
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_NAME)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_NAME)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public String getName() {
         return name;
     }
 
     @JsonProperty(JSON_PROPERTY_NAME)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setName(String name) {
         this.name = name;
     }
@@ -105,14 +106,15 @@ public class TeamResponse {
      *
      * @return accounts
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_ACCOUNTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public List<AccountResponse> getAccounts() {
         return accounts;
     }
 
     @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setAccounts(List<AccountResponse> accounts) {
         this.accounts = accounts;
     }
@@ -136,14 +138,15 @@ public class TeamResponse {
      *
      * @return invitedAccounts
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_INVITED_ACCOUNTS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_INVITED_ACCOUNTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public List<AccountResponse> getInvitedAccounts() {
         return invitedAccounts;
     }
 
     @JsonProperty(JSON_PROPERTY_INVITED_ACCOUNTS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setInvitedAccounts(List<AccountResponse> invitedAccounts) {
         this.invitedAccounts = invitedAccounts;
     }
@@ -167,14 +170,15 @@ public class TeamResponse {
      *
      * @return invitedEmails
      */
-    @javax.annotation.Nullable @JsonProperty(JSON_PROPERTY_INVITED_EMAILS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @javax.annotation.Nonnull
+    @JsonProperty(JSON_PROPERTY_INVITED_EMAILS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public List<String> getInvitedEmails() {
         return invitedEmails;
     }
 
     @JsonProperty(JSON_PROPERTY_INVITED_EMAILS)
-    @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+    @JsonInclude(value = JsonInclude.Include.ALWAYS)
     public void setInvitedEmails(List<String> invitedEmails) {
         this.invitedEmails = invitedEmails;
     }

--- a/sdks/java-v2/docs/TeamResponse.md
+++ b/sdks/java-v2/docs/TeamResponse.md
@@ -8,10 +8,10 @@ Contains information about your team and its members
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| `name` | ```String``` |  The name of your Team  |  |
-| `accounts` | [```List<AccountResponse>```](AccountResponse.md) |    |  |
-| `invitedAccounts` | [```List<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
-| `invitedEmails` | ```List<String>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
+| `name`<sup>*_required_</sup> | ```String``` |  The name of your Team  |  |
+| `accounts`<sup>*_required_</sup> | [```List<AccountResponse>```](AccountResponse.md) |    |  |
+| `invitedAccounts`<sup>*_required_</sup> | [```List<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
+| `invitedEmails`<sup>*_required_</sup> | ```List<String>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
 
 
 

--- a/sdks/java-v2/src/main/java/com/dropbox/sign/model/TeamResponse.java
+++ b/sdks/java-v2/src/main/java/com/dropbox/sign/model/TeamResponse.java
@@ -48,13 +48,13 @@ public class TeamResponse {
   private String name;
 
   public static final String JSON_PROPERTY_ACCOUNTS = "accounts";
-  private List<AccountResponse> accounts = null;
+  private List<AccountResponse> accounts = new ArrayList<>();
 
   public static final String JSON_PROPERTY_INVITED_ACCOUNTS = "invited_accounts";
-  private List<AccountResponse> invitedAccounts = null;
+  private List<AccountResponse> invitedAccounts = new ArrayList<>();
 
   public static final String JSON_PROPERTY_INVITED_EMAILS = "invited_emails";
-  private List<String> invitedEmails = null;
+  private List<String> invitedEmails = new ArrayList<>();
 
   public TeamResponse() { 
   }
@@ -83,9 +83,9 @@ public class TeamResponse {
    * The name of your Team
    * @return name
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public String getName() {
     return name;
@@ -93,7 +93,7 @@ public class TeamResponse {
 
 
   @JsonProperty(JSON_PROPERTY_NAME)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setName(String name) {
     this.name = name;
   }
@@ -116,9 +116,9 @@ public class TeamResponse {
    * Get accounts
    * @return accounts
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public List<AccountResponse> getAccounts() {
     return accounts;
@@ -126,7 +126,7 @@ public class TeamResponse {
 
 
   @JsonProperty(JSON_PROPERTY_ACCOUNTS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setAccounts(List<AccountResponse> accounts) {
     this.accounts = accounts;
   }
@@ -149,9 +149,9 @@ public class TeamResponse {
    * A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in &#x60;GET /account&#x60;.
    * @return invitedAccounts
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_INVITED_ACCOUNTS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public List<AccountResponse> getInvitedAccounts() {
     return invitedAccounts;
@@ -159,7 +159,7 @@ public class TeamResponse {
 
 
   @JsonProperty(JSON_PROPERTY_INVITED_ACCOUNTS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setInvitedAccounts(List<AccountResponse> invitedAccounts) {
     this.invitedAccounts = invitedAccounts;
   }
@@ -182,9 +182,9 @@ public class TeamResponse {
    * A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.
    * @return invitedEmails
    */
-  @jakarta.annotation.Nullable
+  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_INVITED_EMAILS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
   public List<String> getInvitedEmails() {
     return invitedEmails;
@@ -192,7 +192,7 @@ public class TeamResponse {
 
 
   @JsonProperty(JSON_PROPERTY_INVITED_EMAILS)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  @JsonInclude(value = JsonInclude.Include.ALWAYS)
   public void setInvitedEmails(List<String> invitedEmails) {
     this.invitedEmails = invitedEmails;
   }

--- a/sdks/node/docs/model/TeamResponse.md
+++ b/sdks/node/docs/model/TeamResponse.md
@@ -6,9 +6,9 @@ Contains information about your team and its members
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `name` | ```string``` |  The name of your Team  |  |
-| `accounts` | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
-| `invitedAccounts` | [```Array<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
-| `invitedEmails` | ```Array<string>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
+| `name`<sup>*_required_</sup> | ```string``` |  The name of your Team  |  |
+| `accounts`<sup>*_required_</sup> | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
+| `invitedAccounts`<sup>*_required_</sup> | [```Array<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
+| `invitedEmails`<sup>*_required_</sup> | ```Array<string>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/node/model/teamResponse.ts
+++ b/sdks/node/model/teamResponse.ts
@@ -32,16 +32,16 @@ export class TeamResponse {
   /**
    * The name of your Team
    */
-  "name"?: string;
-  "accounts"?: Array<AccountResponse>;
+  "name": string;
+  "accounts": Array<AccountResponse>;
   /**
    * A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.
    */
-  "invitedAccounts"?: Array<AccountResponse>;
+  "invitedAccounts": Array<AccountResponse>;
   /**
    * A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.
    */
-  "invitedEmails"?: Array<string>;
+  "invitedEmails": Array<string>;
 
   static discriminator: string | undefined = undefined;
 

--- a/sdks/node/types/model/teamResponse.d.ts
+++ b/sdks/node/types/model/teamResponse.d.ts
@@ -1,10 +1,10 @@
 import { AttributeTypeMap } from "./";
 import { AccountResponse } from "./accountResponse";
 export declare class TeamResponse {
-    "name"?: string;
-    "accounts"?: Array<AccountResponse>;
-    "invitedAccounts"?: Array<AccountResponse>;
-    "invitedEmails"?: Array<string>;
+    "name": string;
+    "accounts": Array<AccountResponse>;
+    "invitedAccounts": Array<AccountResponse>;
+    "invitedEmails": Array<string>;
     static discriminator: string | undefined;
     static attributeTypeMap: AttributeTypeMap;
     static getAttributeTypeMap(): AttributeTypeMap;

--- a/sdks/php/docs/Model/TeamResponse.md
+++ b/sdks/php/docs/Model/TeamResponse.md
@@ -6,9 +6,9 @@ Contains information about your team and its members
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `name` | ```string``` |  The name of your Team  |  |
-| `accounts` | [```\Dropbox\Sign\Model\AccountResponse[]```](AccountResponse.md) |    |  |
-| `invited_accounts` | [```\Dropbox\Sign\Model\AccountResponse[]```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
-| `invited_emails` | ```string[]``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
+| `name`<sup>*_required_</sup> | ```string``` |  The name of your Team  |  |
+| `accounts`<sup>*_required_</sup> | [```\Dropbox\Sign\Model\AccountResponse[]```](AccountResponse.md) |    |  |
+| `invited_accounts`<sup>*_required_</sup> | [```\Dropbox\Sign\Model\AccountResponse[]```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
+| `invited_emails`<sup>*_required_</sup> | ```string[]``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)

--- a/sdks/php/src/Model/TeamResponse.php
+++ b/sdks/php/src/Model/TeamResponse.php
@@ -303,7 +303,21 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
      */
     public function listInvalidProperties()
     {
-        return [];
+        $invalidProperties = [];
+
+        if ($this->container['name'] === null) {
+            $invalidProperties[] = "'name' can't be null";
+        }
+        if ($this->container['accounts'] === null) {
+            $invalidProperties[] = "'accounts' can't be null";
+        }
+        if ($this->container['invited_accounts'] === null) {
+            $invalidProperties[] = "'invited_accounts' can't be null";
+        }
+        if ($this->container['invited_emails'] === null) {
+            $invalidProperties[] = "'invited_emails' can't be null";
+        }
+        return $invalidProperties;
     }
 
     /**
@@ -320,7 +334,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets name
      *
-     * @return string|null
+     * @return string
      */
     public function getName()
     {
@@ -330,11 +344,11 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets name
      *
-     * @param string|null $name The name of your Team
+     * @param string $name The name of your Team
      *
      * @return self
      */
-    public function setName(?string $name)
+    public function setName(string $name)
     {
         if (is_null($name)) {
             throw new InvalidArgumentException('non-nullable name cannot be null');
@@ -347,7 +361,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets accounts
      *
-     * @return AccountResponse[]|null
+     * @return AccountResponse[]
      */
     public function getAccounts()
     {
@@ -357,11 +371,11 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets accounts
      *
-     * @param AccountResponse[]|null $accounts accounts
+     * @param AccountResponse[] $accounts accounts
      *
      * @return self
      */
-    public function setAccounts(?array $accounts)
+    public function setAccounts(array $accounts)
     {
         if (is_null($accounts)) {
             throw new InvalidArgumentException('non-nullable accounts cannot be null');
@@ -374,7 +388,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets invited_accounts
      *
-     * @return AccountResponse[]|null
+     * @return AccountResponse[]
      */
     public function getInvitedAccounts()
     {
@@ -384,11 +398,11 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets invited_accounts
      *
-     * @param AccountResponse[]|null $invited_accounts A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.
+     * @param AccountResponse[] $invited_accounts A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.
      *
      * @return self
      */
-    public function setInvitedAccounts(?array $invited_accounts)
+    public function setInvitedAccounts(array $invited_accounts)
     {
         if (is_null($invited_accounts)) {
             throw new InvalidArgumentException('non-nullable invited_accounts cannot be null');
@@ -401,7 +415,7 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Gets invited_emails
      *
-     * @return string[]|null
+     * @return string[]
      */
     public function getInvitedEmails()
     {
@@ -411,11 +425,11 @@ class TeamResponse implements ModelInterface, ArrayAccess, JsonSerializable
     /**
      * Sets invited_emails
      *
-     * @param string[]|null $invited_emails a list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account
+     * @param string[] $invited_emails a list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account
      *
      * @return self
      */
-    public function setInvitedEmails(?array $invited_emails)
+    public function setInvitedEmails(array $invited_emails)
     {
         if (is_null($invited_emails)) {
             throw new InvalidArgumentException('non-nullable invited_emails cannot be null');

--- a/sdks/python/docs/TeamResponse.md
+++ b/sdks/python/docs/TeamResponse.md
@@ -5,10 +5,10 @@ Contains information about your team and its members
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-| `name` | ```str``` |  The name of your Team  |  |
-| `accounts` | [```List[AccountResponse]```](AccountResponse.md) |    |  |
-| `invited_accounts` | [```List[AccountResponse]```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
-| `invited_emails` | ```List[str]``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
+| `name`<sup>*_required_</sup> | ```str``` |  The name of your Team  |  |
+| `accounts`<sup>*_required_</sup> | [```List[AccountResponse]```](AccountResponse.md) |    |  |
+| `invited_accounts`<sup>*_required_</sup> | [```List[AccountResponse]```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
+| `invited_emails`<sup>*_required_</sup> | ```List[str]``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdks/python/dropbox_sign/models/team_response.py
+++ b/sdks/python/dropbox_sign/models/team_response.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List
 from dropbox_sign.models.account_response import AccountResponse
 from typing import Optional, Set, Tuple
 from typing_extensions import Self
@@ -33,15 +33,13 @@ class TeamResponse(BaseModel):
     Contains information about your team and its members
     """  # noqa: E501
 
-    name: Optional[StrictStr] = Field(default=None, description="The name of your Team")
-    accounts: Optional[List[AccountResponse]] = None
-    invited_accounts: Optional[List[AccountResponse]] = Field(
-        default=None,
-        description="A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.",
+    name: StrictStr = Field(description="The name of your Team")
+    accounts: List[AccountResponse]
+    invited_accounts: List[AccountResponse] = Field(
+        description="A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`."
     )
-    invited_emails: Optional[List[StrictStr]] = Field(
-        default=None,
-        description="A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.",
+    invited_emails: List[StrictStr] = Field(
+        description="A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account."
     )
     __properties: ClassVar[List[str]] = [
         "name",

--- a/sdks/ruby/docs/TeamResponse.md
+++ b/sdks/ruby/docs/TeamResponse.md
@@ -6,8 +6,8 @@ Contains information about your team and its members
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| `name` | ```String``` |  The name of your Team  |  |
-| `accounts` | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
-| `invited_accounts` | [```Array<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
-| `invited_emails` | ```Array<String>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
+| `name`<sup>*_required_</sup> | ```String``` |  The name of your Team  |  |
+| `accounts`<sup>*_required_</sup> | [```Array<AccountResponse>```](AccountResponse.md) |    |  |
+| `invited_accounts`<sup>*_required_</sup> | [```Array<AccountResponse>```](AccountResponse.md) |  A list of all Accounts that have an outstanding invitation to join your Team. Note that this response is a subset of the response parameters found in `GET /account`.  |  |
+| `invited_emails`<sup>*_required_</sup> | ```Array<String>``` |  A list of email addresses that have an outstanding invitation to join your Team and do not yet have a Dropbox Sign account.  |  |
 

--- a/sdks/ruby/lib/dropbox-sign/models/team_response.rb
+++ b/sdks/ruby/lib/dropbox-sign/models/team_response.rb
@@ -132,12 +132,32 @@ module Dropbox::Sign
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
+      if @name.nil?
+        invalid_properties.push('invalid value for "name", name cannot be nil.')
+      end
+
+      if @accounts.nil?
+        invalid_properties.push('invalid value for "accounts", accounts cannot be nil.')
+      end
+
+      if @invited_accounts.nil?
+        invalid_properties.push('invalid value for "invited_accounts", invited_accounts cannot be nil.')
+      end
+
+      if @invited_emails.nil?
+        invalid_properties.push('invalid value for "invited_emails", invited_emails cannot be nil.')
+      end
+
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
+      return false if @name.nil?
+      return false if @accounts.nil?
+      return false if @invited_accounts.nil?
+      return false if @invited_emails.nil?
       true
     end
 

--- a/test_fixtures/TeamGetResponse.json
+++ b/test_fixtures/TeamGetResponse.json
@@ -28,6 +28,11 @@
             "api_signature_requests_left": 0
           }
         }
+      ],
+      "invited_emails": [
+        "invite_1@example.com",
+        "invite_2@example.com",
+        "invite_3@example.com"
       ]
     }
   }


### PR DESCRIPTION
`TeamResponse` updated. The following properties are now non-nullable:

* `name`
* `accounts`
* `invited_accounts`
* `invited_emails`