### PR TITLE
[SIGN-15354] Fix ruby SDK for multipart PUT when it is generated with Typhoeus HTTP client

### DIFF
--- a/sdks/ruby/lib/dropbox-sign/api_client.rb
+++ b/sdks/ruby/lib/dropbox-sign/api_client.rb
@@ -132,6 +132,22 @@ module Dropbox::Sign
         end
       end
 
+      # Workaround for the Typhoeus/libcurl multipart PUT bug.
+      # libcurl only builds a multipart body via CURLOPT_HTTPPOST/CURLOPT_MIMEPOST,
+      # which is engaged for POST requests. For PUT it falls back to CURLOPT_UPLOAD
+      # and silently drops form fields, so the request is sent without a
+      # `Content-Type: multipart/form-data; boundary=...` header or body.
+      # We send the request as POST so the multipart body is encoded correctly,
+      # then use CURLOPT_CUSTOMREQUEST (exposed by Ethon as :customrequest) to
+      # restore PUT as the on-the-wire HTTP verb.
+      # See: https://github.com/typhoeus/typhoeus/issues/389
+      content_type_header = header_params['Content-Type'] || header_params['content-type']
+      if http_method == :put && content_type_header.is_a?(String) &&
+         content_type_header.start_with?('multipart/form-data')
+        req_opts[:method] = :post
+        req_opts[:customrequest] = 'PUT'
+      end
+
       Typhoeus::Request.new(url, req_opts)
     end
 

--- a/sdks/ruby/templates/api_client_typhoeus_partial.mustache
+++ b/sdks/ruby/templates/api_client_typhoeus_partial.mustache
@@ -87,6 +87,22 @@
         end
       end
 
+      # Workaround for the Typhoeus/libcurl multipart PUT bug.
+      # libcurl only builds a multipart body via CURLOPT_HTTPPOST/CURLOPT_MIMEPOST,
+      # which is engaged for POST requests. For PUT it falls back to CURLOPT_UPLOAD
+      # and silently drops form fields, so the request is sent without a
+      # `Content-Type: multipart/form-data; boundary=...` header or body.
+      # We send the request as POST so the multipart body is encoded correctly,
+      # then use CURLOPT_CUSTOMREQUEST (exposed by Ethon as :customrequest) to
+      # restore PUT as the on-the-wire HTTP verb.
+      # See: https://github.com/typhoeus/typhoeus/issues/389
+      content_type_header = header_params['Content-Type'] || header_params['content-type']
+      if http_method == :put && content_type_header.is_a?(String) &&
+         content_type_header.start_with?('multipart/form-data')
+        req_opts[:method] = :post
+        req_opts[:customrequest] = 'PUT'
+      end
+
       Typhoeus::Request.new(url, req_opts)
     end
 


### PR DESCRIPTION
Fix Ruby client Typhoeus bug with multipart PUT request. Now sdk-tester passes for Ruby:

<img width="3444" height="1398" alt="Screenshot 2026-05-08 at 12 39 36" src="https://github.com/user-attachments/assets/39f456b4-92d4-49d2-b4ac-50d5a0ec41b8" />
