### PR TITLE
Document text tag extraction error handling

### DIFF
--- a/openapi-fern.yaml
+++ b/openapi-fern.yaml
@@ -24102,6 +24102,10 @@ components:
           description: Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.
           type: boolean
           default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
+          type: boolean
+          default: false
         expires_at:
           description: When the signature request will expire. Unsigned signatures will be moved to the expired status, and no longer signable. See [Signature Request Expiration Date](https://developers.hellosign.com/docs/signature-request/expiration/) for details.
           type: integer
@@ -24245,6 +24249,10 @@ components:
           maxLength: 255
         use_text_tags:
           description: Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
           type: boolean
           default: false
         populate_auto_fill_fields:
@@ -24590,6 +24598,10 @@ components:
           maxLength: 255
         use_text_tags:
           description: Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
           type: boolean
           default: false
         expires_at:
@@ -25929,6 +25941,10 @@ components:
           description: Enable the detection of predefined PDF fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`).
           type: boolean
           default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
+          type: boolean
+          default: false
       type: object
     TemplateCreateEmbeddedDraftRequest:
       required:
@@ -26069,6 +26085,10 @@ components:
           type: string
         use_preexisting_fields:
           description: Enable the detection of predefined PDF fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`).
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
           type: boolean
           default: false
       type: object
@@ -26248,6 +26268,10 @@ components:
           default: false
         use_text_tags:
           description: Set `use_text_tags` to `true` to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document (defaults to disabled, or `false`). Alternatively, if your PDF contains pre-defined fields, enable the detection of these fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`). Currently we only support use of either `use_text_tags` or `use_preexisting_fields` parameter, not both.
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
           type: boolean
           default: false
         expires_at:
@@ -26438,6 +26462,10 @@ components:
           default: false
         use_text_tags:
           description: Set `use_text_tags` to `true` to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document (defaults to disabled, or `false`). Alternatively, if your PDF contains pre-defined fields, enable the detection of these fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`). Currently we only support use of either `use_text_tags` or `use_preexisting_fields` parameter, not both.
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.
           type: boolean
           default: false
         populate_auto_fill_fields:

--- a/openapi-raw.yaml
+++ b/openapi-raw.yaml
@@ -8715,7 +8715,6 @@ components:
           description: '_t__SignatureRequestSend::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         expires_at:
           description: '_t__SignatureRequestSend::EXPIRES_AT'
           type: integer
@@ -8833,7 +8832,6 @@ components:
           description: '_t__SignatureRequestCreateEmbedded::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         populate_auto_fill_fields:
           description: '_t__SignatureRequestCreateEmbedded::POPULATE_AUTO_FILL_FIELDS'
           type: boolean
@@ -9141,7 +9139,6 @@ components:
           description: '_t__SignatureRequestSend::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         expires_at:
           description: '_t__SignatureRequestSend::EXPIRES_AT'
           type: integer
@@ -10333,7 +10330,6 @@ components:
           description: '_t__TemplateCreate::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         signer_experience:
           description: '_t__TemplateCreate::SIGNER_EXPERIENCE'
           allOf:
@@ -10456,7 +10452,6 @@ components:
           description: '_t__TemplateCreateEmbeddedDraft::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         signer_experience:
           description: '_t__TemplateCreateEmbeddedDraft::SIGNER_EXPERIENCE'
           allOf:
@@ -10649,7 +10644,6 @@ components:
           description: '_t__UnclaimedDraftCreate::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         expires_at:
           description: '_t__UnclaimedDraftCreate::EXPIRES_AT'
           type: integer
@@ -10814,7 +10808,6 @@ components:
           description: '_t__UnclaimedDraftCreateEmbedded::IGNORE_TEXT_TAGS_EXTRACTION_ERRORS'
           type: boolean
           default: false
-          x-hideOn: doc
         populate_auto_fill_fields:
           description: '_t__UnclaimedDraftCreateEmbedded::POPULATE_AUTO_FILL_FIELDS'
           type: boolean

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8804,6 +8804,10 @@ components:
           description: 'Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.'
           type: boolean
           default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
+          type: boolean
+          default: false
         expires_at:
           description: 'When the signature request will expire. Unsigned signatures will be moved to the expired status, and no longer signable. See [Signature Request Expiration Date](https://developers.hellosign.com/docs/signature-request/expiration/) for details.'
           type: integer
@@ -8947,6 +8951,10 @@ components:
           maxLength: 255
         use_text_tags:
           description: 'Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.'
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
           type: boolean
           default: false
         populate_auto_fill_fields:
@@ -9292,6 +9300,10 @@ components:
           maxLength: 255
         use_text_tags:
           description: 'Send with a value of `true` if you wish to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document. Defaults to disabled, or `false`.'
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
           type: boolean
           default: false
         expires_at:
@@ -10641,6 +10653,10 @@ components:
           description: 'Enable the detection of predefined PDF fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`).'
           type: boolean
           default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
+          type: boolean
+          default: false
       type: object
     TemplateCreateEmbeddedDraftRequest:
       required:
@@ -10781,6 +10797,10 @@ components:
           type: string
         use_preexisting_fields:
           description: 'Enable the detection of predefined PDF fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`).'
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
           type: boolean
           default: false
       type: object
@@ -10960,6 +10980,10 @@ components:
           default: false
         use_text_tags:
           description: 'Set `use_text_tags` to `true` to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document (defaults to disabled, or `false`). Alternatively, if your PDF contains pre-defined fields, enable the detection of these fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`). Currently we only support use of either `use_text_tags` or `use_preexisting_fields` parameter, not both.'
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
           type: boolean
           default: false
         expires_at:
@@ -11150,6 +11174,10 @@ components:
           default: false
         use_text_tags:
           description: 'Set `use_text_tags` to `true` to enable [Text Tags](https://app.hellosign.com/api/textTagsWalkthrough#TextTagIntro) parsing in your document (defaults to disabled, or `false`). Alternatively, if your PDF contains pre-defined fields, enable the detection of these fields by setting the `use_preexisting_fields` to `true` (defaults to disabled, or `false`). Currently we only support use of either `use_text_tags` or `use_preexisting_fields` parameter, not both.'
+          type: boolean
+          default: false
+        ignore_text_tags_extraction_errors:
+          description: 'Sent with a value of `true` to ignore the validation errors from text tags extraction. Defaults to `false`.'
           type: boolean
           default: false
         populate_auto_fill_fields:


### PR DESCRIPTION
## What changed

- Regenerated the public OpenAPI documentation to show `ignore_text_tags_extraction_errors` across supported signature request, template, and unclaimed draft request models.
- Regenerated the Fern-specific OpenAPI document.
- Kept the SDK-specific specification and generated SDKs unchanged.

## Customer impact

Developers can now discover how to ignore text-tag extraction validation errors directly in the API reference.

## Validation

- `./build` (no untranslated strings)
- `./generate-sdks -t all`
- `git diff --check`
